### PR TITLE
Fix path to Sleet.exe from props

### DIFF
--- a/build/nupkgIncludes/Sleet.props
+++ b/build/nupkgIncludes/Sleet.props
@@ -2,6 +2,6 @@
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <!-- Allow finding the path to Sleet.exe through msbuild. -->
-    <Sleet>$(MSBuildThisFileDirectory)..\tools\Sleet.exe</Sleet>
+    <Sleet>$(MSBuildThisFileDirectory)..\..\tools\Sleet.exe</Sleet>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Since the props is imported from build\net46\Sleep.props, this should have been ..\..\tools\Sleet.exe