### PR TITLE
Fix the dependency graph when building for netcoreapp2.0

### DIFF
--- a/src/Sleet/Sleet.csproj
+++ b/src/Sleet/Sleet.csproj
@@ -1,5 +1,6 @@
-﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
+﻿<Project ToolsVersion="15.0">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\build\common\common.props" />
+  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
 
   <PropertyGroup Condition=" '$(IsXPlat)' != 'true' ">
     <TargetFrameworks>netcoreapp2.0;net46</TargetFrameworks>
@@ -73,5 +74,5 @@
     <MSBuild Projects="$(MSBuildProjectFullPath)" Targets="Pack" Condition=" '$(IsXPlat)' != 'true' " Properties="Configuration=$(Configuration);&#xD;&#xA;                         PackageOutputPath=$(NupkgOutputDirectory);&#xD;&#xA;                         NoPackageAnalysis=true;&#xD;&#xA;                         IncludeSymbols=false;&#xD;&#xA;                         IsTool=true;&#xD;&#xA;                         NuspecFile=Sleet.nuspec;&#xD;&#xA;                         NuspecProperties=$(NuspecProperties)">
     </MSBuild>
   </Target>
-
+  <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 </Project>

--- a/src/SleetLib/SleetLib.csproj
+++ b/src/SleetLib/SleetLib.csproj
@@ -1,6 +1,6 @@
-﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
+﻿<Project ToolsVersion="15.0">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\build\common\common.props" />
-
+  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
   <PropertyGroup Condition=" '$(IsXPlat)' != 'true' ">
     <TargetFrameworks>netstandard2.0;netstandard1.3;net46;net45</TargetFrameworks>
   </PropertyGroup>
@@ -15,7 +15,7 @@
     <Description>Access Sleet.exe commands through the Sleet API.</Description>
     <PackProject>true</PackProject>
   </PropertyGroup>
-  
+
   <PropertyGroup Condition="'$(TargetFramework)' == 'net45' Or '$(TargetFramework)' == 'netstandard1.3'">
     <DefineConstants>USEJSONNET901</DefineConstants>
     <UseJsonNet901>true</UseJsonNet901>
@@ -24,11 +24,11 @@
   <ItemGroup>
     <EmbeddedResource Include="compiler\resources\**\*" />
   </ItemGroup>
-  
+
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' OR '$(TargetFramework)' == 'net45' ">
     <Reference Include="System.IO.Compression" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <PackageReference Include="NuGet.Packaging" Version="$(NuGetPackageVersion)" Condition=" '$(UseJsonNet901)' != 'true' " />
     <PackageReference Include="NuGet.Packaging" Version="4.3.0" Condition=" '$(UseJsonNet901)' == 'true' " />
@@ -37,11 +37,12 @@
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" Condition=" '$(UseJsonNet901)' == 'true' " />
     <PackageReference Include="Microsoft.DiaSymReader.PortablePdb" Version="$(PortablePdbVersion)" />
   </ItemGroup>
-  
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netstandard1.3' ">
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
     <PackageReference Include="System.IO.FileSystem" Version="4.3.0" />
     <PackageReference Include="System.Collections.Concurrent" Version="4.3.0" />
   </ItemGroup>
 
   <Import Project="$(BuildCommonDirectory)\common.targets" />
+  <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 </Project>

--- a/test/Sleet.Test.Common/Sleet.Test.Common.csproj
+++ b/test/Sleet.Test.Common/Sleet.Test.Common.csproj
@@ -1,6 +1,6 @@
-<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
+<Project ToolsVersion="15.0">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\build\common\common.props" />
-
+  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
   <PropertyGroup Condition=" '$(IsXPlat)' != 'true' ">
     <TargetFrameworks>netstandard2.0;net46;netstandard1.3</TargetFrameworks>
   </PropertyGroup>
@@ -30,4 +30,5 @@
   </ItemGroup>
 
   <Import Project="$(BuildCommonDirectory)\common.targets" />
+  <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 </Project>


### PR DESCRIPTION
Currently, the netcoreapp2.0 version of Sleet.dll doesn't run. It fails with
```
Unhandled Exception: System.IO.FileLoadException: Could not load file or assembly 'System.Linq, Version=4.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'. The located assembly's manifest definition does not match the assembly reference. (Exception from HRESULT: 0x80131040)
   at Sleet.CmdUtils.LaunchDebuggerIfSet(String[]& args, ILogger logger)
   at Sleet.Program.MainCore(String[] args, ILogger log)
   at Sleet.Program.Main(String[] args)
```
NETStandard.Library.targets were not imported at all due to BaseIntermedateOutputPath not being set in the right order (see https://github.com/Microsoft/msbuild/issues/1603). This changes the import order so the targets are found