### PR TITLE
Extract the nuspec file from the package

### DIFF
--- a/src/SleetLib/Services/FlatContainer.cs
+++ b/src/SleetLib/Services/FlatContainer.cs
@@ -31,7 +31,7 @@ namespace Sleet
             var nuspecPath = $"{packageInput.Identity.Id}.nuspec".ToLowerInvariant();
 
             var nuspecEntry = await packageInput.RunWithLockAsync((p) => Task.FromResult(p.Zip.Entries
-                .Where(entry => nuspecPath.Equals(nuspecPath, StringComparison.OrdinalIgnoreCase))
+                .Where(entry => entry.FullName.Equals(nuspecPath, StringComparison.OrdinalIgnoreCase))
                 .FirstOrDefault()));
 
             if (nuspecEntry == null)


### PR DESCRIPTION
With this change, Sleet will extract the `.nuspec` file from the package, even if it's not the first entry in the Zip archive.

Looks like the `.nuspec` happens to be the first entry if the package was created with NuGet, but not with Paket.