### PR TITLE
Add batch APIs to improve performance

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,5 +1,10 @@
 # Release Notes
 
+## 2.4.0
+* Performance improvements, packages are added in batch to reduce the number of file read/writes.
+* Add/removes within a service are done in parallel where possible.
+* nupkg files are read in parallel before locking the feed to reduce the amount of time spent in the lock. 
+
 ## 2.3.33
 * Local feeds will contian baseURI by default when using createconfig.
 * Local feeds will fail if path contains an http URI. baseURI should be used instead.

--- a/src/SleetLib/Commands/StatsCommand.cs
+++ b/src/SleetLib/Commands/StatsCommand.cs
@@ -36,11 +36,14 @@ namespace Sleet
                 };
 
                 var packageIndex = new PackageIndex(context);
+                var existingPackageSets = await packageIndex.GetPackageSetsAsync();
 
-                var packages = await packageIndex.GetPackagesAsync();
-                var uniqueIds = packages.Select(e => e.Id).Distinct(StringComparer.OrdinalIgnoreCase);
+                var uniqueIds = existingPackageSets.Packages.Index
+                    .Concat(existingPackageSets.Symbols.Index)
+                    .Select(e => e.Id).Distinct(StringComparer.OrdinalIgnoreCase);
 
-                log.LogMinimal($"Packages: {packages.Count}");
+                log.LogMinimal($"Packages: {existingPackageSets.Packages.Index.Count}");
+                log.LogMinimal($"Symbols Packages: {existingPackageSets.Symbols.Index.Count}");
                 log.LogMinimal($"Unique package ids: {uniqueIds.Count()}");
             }
 

--- a/src/SleetLib/Common/JsonLDTokenComparer.cs
+++ b/src/SleetLib/Common/JsonLDTokenComparer.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Newtonsoft.Json.Linq;
@@ -20,28 +20,27 @@ namespace Sleet
         /// <summary>
         /// Apply json-ld formatting
         /// </summary>
-        public static JObject Format(JObject json)
+        public static JObject Format(JObject json, bool recurse=true)
         {
             var children = json.Children().ToList();
             children.Sort(Instance);
 
-            var formatted = new JObject();
-            foreach (var child in children)
+            json.RemoveAll();
+            for (var i = 0; i < children.Count; i++)
             {
-                var childObj = child as JObject;
-                var childArray = child as JArray;
+                var child = children[i];
 
-                if (childObj != null)
+                if (recurse && child.Type == JTokenType.Object)
                 {
-                    formatted.Add(Format(childObj));
+                    json.Add(Format((JObject)child));
                 }
                 else
                 {
-                    formatted.Add(child);
+                    json.Add(child);
                 }
             }
 
-            return formatted;
+            return json;
         }
 
         public int Compare(JToken x, JToken y)

--- a/src/SleetLib/Common/PackageSet.cs
+++ b/src/SleetLib/Common/PackageSet.cs
@@ -39,5 +39,26 @@ namespace Sleet
 
             return Task.FromResult(true);
         }
+
+        public async Task AddPackagesAsync(IEnumerable<PackageInput> packageInputs)
+        {
+            foreach (var input in packageInputs)
+            {
+                await AddPackageAsync(input);
+            }
+        }
+
+        public async Task RemovePackagesAsync(IEnumerable<PackageIdentity> packageInputs)
+        {
+            foreach (var input in packageInputs)
+            {
+                await RemovePackageAsync(input);
+            }
+        }
+
+        public bool Exists(PackageIdentity package)
+        {
+            return Index.Contains(package);
+        }
     }
 }

--- a/src/SleetLib/Common/PackageSets.cs
+++ b/src/SleetLib/Common/PackageSets.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Sleet
+{
+    /// <summary>
+    /// Represents all entries in PackageIndexFile
+    /// </summary>
+    public class PackageSets
+    {
+        public PackageSet Packages { get; set; } = new PackageSet();
+
+        public PackageSet Symbols { get; set; } = new PackageSet();
+    }
+}

--- a/src/SleetLib/Services/AutoComplete.cs
+++ b/src/SleetLib/Services/AutoComplete.cs
@@ -23,71 +23,16 @@ namespace Sleet
             _context = context;
         }
 
-        public ISleetFile RootIndexFile
+        public ISleetFile RootIndexFile => _context.Source.Get(RootIndex);
+
+        public Task AddPackageAsync(PackageInput packageInput)
         {
-            get
-            {
-                return _context.Source.Get(RootIndex);
-            }
+            return AddPackagesAsync(new[] { packageInput });
         }
 
-        public async Task AddPackageAsync(PackageInput packageInput)
+        public Task RemovePackageAsync(PackageIdentity packageIdentity)
         {
-            var file = RootIndexFile;
-            var json = await file.GetJson(_context.Log, _context.Token);
-
-            var data = json["data"] as JArray;
-
-            var ids = await GetPackageIds();
-
-            ids.Add(packageInput.Identity.Id);
-
-            data.Clear();
-
-            foreach (var id in ids.OrderBy(s => s, StringComparer.OrdinalIgnoreCase))
-            {
-                data.Add(id);
-            }
-
-            json["totalHits"] = ids.Count;
-
-            json = JsonLDTokenComparer.Format(json);
-
-            await file.Write(json, _context.Log, _context.Token);
-        }
-
-        public async Task RemovePackageAsync(PackageIdentity packageIdentity)
-        {
-            var packageIndex = new PackageIndex(_context);
-            var allPackagesForId = await packageIndex.GetPackagesByIdAsync(packageIdentity.Id);
-            allPackagesForId.Remove(packageIdentity);
-
-            // Only remove the package if all versions have been removed
-            if (allPackagesForId.Count == 0)
-            {
-                var file = RootIndexFile;
-                var json = await file.GetJson(_context.Log, _context.Token);
-
-                var data = json["data"] as JArray;
-
-                var ids = await GetPackageIds();
-
-                if (ids.Remove(packageIdentity.Id))
-                {
-                    data.Clear();
-
-                    foreach (var id in ids.OrderBy(s => s, StringComparer.OrdinalIgnoreCase))
-                    {
-                        data.Add(id);
-                    }
-
-                    json["totalHits"] = ids.Count;
-
-                    json = JsonLDTokenComparer.Format(json);
-
-                    await file.Write(json, _context.Log, _context.Token);
-                }
-            }
+            return RemovePackagesAsync(new[] { packageIdentity });
         }
 
         /// <summary>
@@ -110,6 +55,56 @@ namespace Sleet
         public Task FetchAsync()
         {
             return RootIndexFile.FetchAsync(_context.Log, _context.Token);
+        }
+
+        public async Task AddPackagesAsync(IEnumerable<PackageInput> packageInputs)
+        {
+            var ids = await GetPackageIds();
+            var prevCount = ids.Count;
+            ids.UnionWith(packageInputs.Select(e => e.Identity.Id));
+
+            // Only update the file if needed.
+            if (prevCount != ids.Count)
+            {
+                var file = RootIndexFile;
+                var json = await file.GetJson(_context.Log, _context.Token);
+                var data = json["data"] as JArray;
+                data.Clear();
+
+                foreach (var id in ids.OrderBy(s => s, StringComparer.OrdinalIgnoreCase))
+                {
+                    data.Add(id);
+                }
+
+                json["totalHits"] = ids.Count;
+                await file.Write(json, _context.Log, _context.Token);
+            }
+        }
+
+        public async Task RemovePackagesAsync(IEnumerable<PackageIdentity> packages)
+        {
+            var packageIndex = new PackageIndex(_context);
+            var allPackages = await packageIndex.GetPackagesAsync();
+            var after = new HashSet<PackageIdentity>(allPackages.Except(packages));
+            var allPackagesIds = new HashSet<string>(allPackages.Select(e => e.Id), StringComparer.OrdinalIgnoreCase);
+            var afterIds = new HashSet<string>(after.Select(e => e.Id), StringComparer.OrdinalIgnoreCase);
+
+            // Only update if needed
+            if (allPackagesIds.Count != afterIds.Count)
+            {
+                var file = RootIndexFile;
+                var json = await file.GetJson(_context.Log, _context.Token);
+                var data = json["data"] as JArray;
+                data.Clear();
+
+                foreach (var id in afterIds.OrderBy(s => s, StringComparer.OrdinalIgnoreCase))
+                {
+                    data.Add(id);
+                }
+
+                json["totalHits"] = after.Count;
+                await file.Write(json, _context.Log, _context.Token);
+            }
         }
     }
 }

--- a/src/SleetLib/Services/Catalog.cs
+++ b/src/SleetLib/Services/Catalog.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
 using NuGet.Packaging.Core;
@@ -31,13 +32,7 @@ namespace Sleet
         /// <summary>
         /// Catalog index.json file
         /// </summary>
-        public ISleetFile RootIndexFile
-        {
-            get
-            {
-                return _context.Source.Get(RootIndex);
-            }
-        }
+        public ISleetFile RootIndexFile => _context.Source.Get(RootIndex);
 
         /// <summary>
         /// Example: http://tempuri.org/catalog/
@@ -58,12 +53,43 @@ namespace Sleet
         /// <summary>
         /// Add a package to the catalog.
         /// </summary>
-        public async Task AddPackageAsync(PackageInput packageInput)
+        public Task AddPackageAsync(PackageInput packageInput)
+        {
+            return AddPackagesAsync(new[] { packageInput });
+        }
+
+        public Task RemovePackageAsync(PackageIdentity package)
+        {
+            return RemovePackagesAsync(new[] { package });
+        }
+
+        public async Task AddPackagesAsync(IEnumerable<PackageInput> packageInputs)
+        {
+            // Write catalog pages for each package
+            var tasks = packageInputs.Select(e => new Func<Task<JObject>>(() => AddPackageToCatalogAndGetCommit(e)));
+            var pageCommits = await TaskUtils.RunAsync(tasks, useTaskRun: true, token: CancellationToken.None);
+
+            // Add pages to the index as commits
+            await AddCatalogCommits(pageCommits, "nuget:lastCreated");
+        }
+
+        public async Task RemovePackagesAsync(IEnumerable<PackageIdentity> packages)
+        {
+            // Write catalog remove pages for each package
+            var tasks = packages.Select(e => new Func<Task<JObject>>(() => GetRemoveCommit(e)));
+            var pageCommits = await TaskUtils.RunAsync(tasks);
+
+            // Add pages to the index as commits
+            await AddCatalogCommits(pageCommits, "nuget:lastDeleted");
+        }
+
+        /// <summary>
+        /// Adds a catalog page and returns the commit.
+        /// </summary>
+        private async Task<JObject> AddPackageToCatalogAndGetCommit(PackageInput packageInput)
         {
             // Create package details page
-            var addFileList = _context.SourceSettings.CatalogEnabled;
-
-            var packageDetails = await CatalogUtility.CreatePackageDetailsAsync(packageInput, CatalogBaseURI, _context.CommitId, addFileList);
+            var packageDetails = await CatalogUtility.CreatePackageDetailsAsync(packageInput, CatalogBaseURI, _context.CommitId, writeFileList: true);
             var packageDetailsUri = JsonUtility.GetIdUri(packageDetails);
 
             // Add output to the package input for other services to use.
@@ -73,17 +99,18 @@ namespace Sleet
             await packageDetailsFile.Write(packageDetails, _context.Log, _context.Token);
 
             // Create commit
-            var pageCommit = CatalogUtility.CreatePageCommit(
+            return CatalogUtility.CreatePageCommit(
                 packageInput.Identity,
                 packageDetailsUri,
                 _context.CommitId,
                 SleetOperation.Add,
                 "nuget:PackageDetails");
-
-            await AddCatalogEntry(pageCommit, "nuget:lastCreated");
         }
 
-        public async Task RemovePackageAsync(PackageIdentity package)
+        /// <summary>
+        /// Add a remove entry and return the page commit.
+        /// </summary>
+        private async Task<JObject> GetRemoveCommit(PackageIdentity package)
         {
             // Create package details page for the delete
             var packageDetails = await CatalogUtility.CreateDeleteDetailsAsync(package, string.Empty, CatalogBaseURI, _context.CommitId);
@@ -92,14 +119,12 @@ namespace Sleet
             await packageDetailsFile.Write(packageDetails, _context.Log, _context.Token);
 
             // Create commit
-            var pageCommit = CatalogUtility.CreatePageCommit(
+            return CatalogUtility.CreatePageCommit(
                 package,
                 packageDetailsFile.EntityUri,
                 _context.CommitId,
                 SleetOperation.Remove,
                 "nuget:PackageDelete");
-
-            await AddCatalogEntry(pageCommit, "nuget:lastDeleted");
         }
 
         /// <summary>
@@ -299,7 +324,7 @@ namespace Sleet
         /// <summary>
         /// Add an entry to the catalog.
         /// </summary>
-        private async Task AddCatalogEntry(JObject pageCommit, string lastUpdatedPropertyName)
+        private async Task AddCatalogCommits(IEnumerable<JObject> newPageCommits, string lastUpdatedPropertyName)
         {
             // Add catalog page entry
             var catalogIndexJson = await RootIndexFile.GetJson(_context.Log, _context.Token);
@@ -331,7 +356,9 @@ namespace Sleet
                 pages = JsonUtility.GetItems(catalogIndexJson);
             }
 
-            pageCommits.Add(pageCommit);
+            // Add all commits, this might go over the max catalog page size.
+            // This could be improved to create new pages once over the limit if needed.
+            pageCommits.AddRange(newPageCommits);
 
             // Write catalog page
             var pageJson = await CatalogUtility.CreateCatalogPageAsync(RootIndexFile.EntityUri, currentPageUri, pageCommits, _context.CommitId);
@@ -350,6 +377,6 @@ namespace Sleet
         public Task FetchAsync()
         {
             return RootIndexFile.FetchAsync(_context.Log, _context.Token);
-        }
+        }        
     }
 }

--- a/src/SleetLib/Services/Symbols.cs
+++ b/src/SleetLib/Services/Symbols.cs
@@ -71,6 +71,9 @@ namespace Sleet
 
             // Wait for everything to finish
             await Task.WhenAll(tasks);
+
+            // Dispose of memory streams
+            assemblies.ForEach(e => e.Dispose());
         }
 
         public async Task RemovePackageAsync(PackageIdentity package)
@@ -109,6 +112,22 @@ namespace Sleet
                 {
                     file.Delete(_context.Log, _context.Token);
                 }
+            }
+        }
+
+        public async Task AddPackagesAsync(IEnumerable<PackageInput> packageInputs)
+        {
+            foreach (var packageInput in packageInputs)
+            {
+                await AddPackageAsync(packageInput);
+            }
+        }
+
+        public async Task RemovePackagesAsync(IEnumerable<PackageIdentity> packages)
+        {
+            foreach (var package in packages)
+            {
+                await RemovePackageAsync(package);
             }
         }
 
@@ -191,10 +210,7 @@ namespace Sleet
             if (await file.Exists(_context.Log, _context.Token) == false)
             {
                 // Write assembly
-                using (var stream = await packageInput.GetEntryStreamWithLockAsync(assembly.ZipEntry))
-                {
-                    await file.Write(stream, _context.Log, _context.Token);
-                }
+                await file.Write(assembly.Stream, _context.Log, _context.Token);
             }
         }
 
@@ -273,69 +289,76 @@ namespace Sleet
             var result = new List<PackageFile>();
             var seen = new HashSet<ISleetFile>();
 
-            var assemblyFiles = await packageInput.RunWithLockAsync(p => Task.FromResult(p.Zip.Entries
-                .Where(e => e.FullName.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
-                .ToList()));
-
-            var pdbFiles = await packageInput.RunWithLockAsync(p => Task.FromResult(p.Zip.Entries
-                .Where(e => e.FullName.EndsWith(".pdb", StringComparison.OrdinalIgnoreCase))
-                .ToList()));
-
-            foreach (var assembly in assemblyFiles)
+            using (var zip = packageInput.CreateZip())
             {
-                string assemblyHash = null;
-                string pdbHash = null;
-                ZipArchiveEntry pdbEntry = null;
-                var valid = false;
+                var assemblyFiles = zip.Entries
+                    .Where(e => e.FullName.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
+                    .ToList();
 
-                try
+                var pdbFiles = zip.Entries
+                    .Where(e => e.FullName.EndsWith(".pdb", StringComparison.OrdinalIgnoreCase))
+                    .ToList();
+
+                foreach (var assembly in assemblyFiles)
                 {
-                    using (var stream = await packageInput.GetEntryStreamWithLockAsync(assembly))
-                    using (var reader = new PEReader(stream))
+                    string assemblyHash = null;
+                    string pdbHash = null;
+                    ZipArchiveEntry pdbEntry = null;
+                    var valid = false;
+                    MemoryStream assemblyStream = null;
+
+                    try
                     {
-                        assemblyHash = SymbolsUtility.GetSymbolHashFromAssembly(reader);
-                        pdbHash = SymbolsUtility.GetPDBHashFromAssembly(reader);
+                        assemblyStream = await assembly.Open().AsMemoryStreamAsync();
+
+                        using (var reader = new PEReader(assemblyStream, PEStreamOptions.LeaveOpen))
+                        {
+                            assemblyHash = SymbolsUtility.GetSymbolHashFromAssembly(reader);
+                            pdbHash = SymbolsUtility.GetPDBHashFromAssembly(reader);
+                        }
+
+                        assemblyStream.Position = 0;
+                        var assemblyWithoutExt = SleetLib.PathUtility.GetFullPathWithoutExtension(assembly.FullName);
+
+                        pdbEntry = pdbFiles.FirstOrDefault(e =>
+                            StringComparer.OrdinalIgnoreCase.Equals(
+                                SleetLib.PathUtility.GetFullPathWithoutExtension(e.FullName), assemblyWithoutExt));
+
+                        valid = true;
+                    }
+                    catch
+                    {
+                        // Ignore bad assemblies
+                        var message = LogMessage.Create(LogLevel.Warning, $"Unable add symbols for {assembly.FullName}, this file will not be present in the symbol server.");
+                        await _context.Log.LogAsync(message);
                     }
 
-                    var assemblyWithoutExt = SleetLib.PathUtility.GetFullPathWithoutExtension(assembly.FullName);
-
-                    pdbEntry = pdbFiles.FirstOrDefault(e =>
-                        StringComparer.OrdinalIgnoreCase.Equals(
-                            SleetLib.PathUtility.GetFullPathWithoutExtension(e.FullName), assemblyWithoutExt));
-
-                    valid = true;
-                }
-                catch
-                {
-                    // Ignore bad assemblies
-                    var message = LogMessage.Create(LogLevel.Warning, $"Unable add symbols for {assembly.FullName}, this file will not be present in the symbol server.");
-                    await _context.Log.LogAsync(message);
-                }
-
-                if (valid)
-                {
-                    // Add .dll
-                    var fileInfo = new FileInfo(assembly.FullName);
-                    var dllFile = _context.Source.Get(SymbolsIndexUtility.GetAssemblyFilePath(fileInfo.Name, assemblyHash));
-                    var indexFile = _context.Source.Get(SymbolsIndexUtility.GetAssemblyToPackageIndexPath(fileInfo.Name, assemblyHash));
-
-                    // Avoid duplicates
-                    if (seen.Add(dllFile))
+                    if (valid)
                     {
-                        result.Add(new PackageFile(fileInfo.Name, assemblyHash, assembly, dllFile, indexFile));
-                    }
-
-                    // Add .pdb
-                    if (pdbEntry != null)
-                    {
-                        var pdbFileInfo = new FileInfo(pdbEntry.FullName);
-                        var pdbFile = _context.Source.Get(SymbolsIndexUtility.GetAssemblyFilePath(pdbFileInfo.Name, pdbHash));
-                        var pdbIndexFile = _context.Source.Get(SymbolsIndexUtility.GetAssemblyToPackageIndexPath(pdbFileInfo.Name, pdbHash));
+                        // Add .dll
+                        var fileInfo = new FileInfo(assembly.FullName);
+                        var dllFile = _context.Source.Get(SymbolsIndexUtility.GetAssemblyFilePath(fileInfo.Name, assemblyHash));
+                        var indexFile = _context.Source.Get(SymbolsIndexUtility.GetAssemblyToPackageIndexPath(fileInfo.Name, assemblyHash));
 
                         // Avoid duplicates
-                        if (seen.Add(pdbFile))
+                        if (seen.Add(dllFile))
                         {
-                            result.Add(new PackageFile(pdbFileInfo.Name, pdbHash, pdbEntry, pdbFile, pdbIndexFile));
+                            result.Add(new PackageFile(fileInfo.Name, assemblyHash, assemblyStream, dllFile, indexFile));
+                        }
+
+                        // Add .pdb
+                        if (pdbEntry != null)
+                        {
+                            var pdbFileInfo = new FileInfo(pdbEntry.FullName);
+                            var pdbFile = _context.Source.Get(SymbolsIndexUtility.GetAssemblyFilePath(pdbFileInfo.Name, pdbHash));
+                            var pdbIndexFile = _context.Source.Get(SymbolsIndexUtility.GetAssemblyToPackageIndexPath(pdbFileInfo.Name, pdbHash));
+
+                            // Avoid duplicates
+                            if (seen.Add(pdbFile))
+                            {
+                                var pdbStream = await pdbEntry.Open().AsMemoryStreamAsync();
+                                result.Add(new PackageFile(pdbFileInfo.Name, pdbHash, pdbStream, pdbFile, pdbIndexFile));
+                            }
                         }
                     }
                 }
@@ -575,25 +598,30 @@ namespace Sleet
         /// <summary>
         /// dll or pdb file
         /// </summary>
-        private class PackageFile
+        private class PackageFile : IDisposable
         {
             public string FileName { get; }
 
             public string Hash { get; }
 
-            public ZipArchiveEntry ZipEntry { get; }
+            public MemoryStream Stream { get; }
 
             public ISleetFile AssetFile { get; }
 
             public ISleetFile IndexFile { get; }
 
-            public PackageFile(string fileName, string hash, ZipArchiveEntry zipEntry, ISleetFile assetFile, ISleetFile indexFile)
+            public PackageFile(string fileName, string hash, MemoryStream stream, ISleetFile assetFile, ISleetFile indexFile)
             {
                 AssetFile = assetFile;
                 FileName = fileName;
                 Hash = hash;
-                ZipEntry = zipEntry;
+                Stream = stream;
                 IndexFile = indexFile;
+            }
+
+            public void Dispose()
+            {
+                Stream?.Dispose();
             }
         }
     }

--- a/src/SleetLib/Services/VirtualCatalog.cs
+++ b/src/SleetLib/Services/VirtualCatalog.cs
@@ -1,4 +1,7 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Packaging.Core;
 
@@ -53,11 +56,9 @@ namespace Sleet
             CatalogBaseURI = catalogBaseURI;
         }
 
-        public async Task AddPackageAsync(PackageInput packageInput)
+        public Task AddPackageAsync(PackageInput packageInput)
         {
-            // Create package details page
-            var packageDetails = await CatalogUtility.CreatePackageDetailsAsync(packageInput, CatalogBaseURI, _context.CommitId, writeFileList: false);
-            packageInput.PackageDetails = packageDetails;
+            return AddPackagesAsync(new[] { packageInput });
         }
 
         public Task RemovePackageAsync(PackageIdentity package)
@@ -66,9 +67,29 @@ namespace Sleet
             return Task.FromResult(true);
         }
 
+        public Task RemovePackagesAsync(IEnumerable<PackageIdentity> packages)
+        {
+            // No actions needed
+            return Task.FromResult(true);
+        }
+
         public Task FetchAsync()
         {
             return RootIndexFile.FetchAsync(_context.Log, _context.Token);
+        }
+
+        public Task AddPackagesAsync(IEnumerable<PackageInput> packageInputs)
+        {
+            // Create package details page
+            var tasks = packageInputs.Select(e => new Func<Task>(() => CreateDetailsForAdd(e)));
+            return TaskUtils.RunAsync(tasks, useTaskRun: true, token: CancellationToken.None);
+        }
+
+        private async Task CreateDetailsForAdd(PackageInput packageInput)
+        {
+            // Create a a details page and assign it to the input
+            var packageDetails = await CatalogUtility.CreatePackageDetailsAsync(packageInput, CatalogBaseURI, _context.CommitId, writeFileList: false);
+            packageInput.PackageDetails = packageDetails;
         }
     }
 }

--- a/src/SleetLib/Utility/Extensions.cs
+++ b/src/SleetLib/Utility/Extensions.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
+using System.Xml.Linq;
 using Newtonsoft.Json.Linq;
 using NuGet.Packaging.Core;
 using NuGet.Versioning;
@@ -125,6 +126,17 @@ namespace Sleet
         public static Uri GetIdUri(this JObject json)
         {
             return JsonUtility.GetIdUri(json);
+        }
+
+        /// <summary>
+        /// Save an XML file to a stream.
+        /// </summary>
+        public static MemoryStream AsMemoryStreamAsync(this XDocument doc)
+        {
+            var mem = new MemoryStream();
+            doc.Save(mem);
+            mem.Position = 0;
+            return mem;
         }
 
         /// <summary>

--- a/src/SleetLib/Utility/SleetUtility.cs
+++ b/src/SleetLib/Utility/SleetUtility.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -8,28 +9,99 @@ namespace Sleet
     public static class SleetUtility
     {
         /// <summary>
+        /// Create a dictionary of packages by id
+        /// </summary>
+        public static Dictionary<string, List<T>> GetPackageSetsById<T>(IEnumerable<T> packages, Func<T, string> getId)
+        {
+            var result = new Dictionary<string, List<T>>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (var package in packages)
+            {
+                var id = getId(package);
+
+                List<T> list = null;
+                if (!result.TryGetValue(id, out list))
+                {
+                    list = new List<T>(1);
+                    result.Add(id, list);
+                }
+
+                list.Add(package);
+            }
+
+            return result;
+        }
+
+        /// <summary>
         /// Add a package to all services.
         /// </summary>
-        public static async Task AddPackage(SleetContext context, PackageInput package)
+        public static Task AddPackage(SleetContext context, PackageInput package)
+        {
+            return AddPackages(context, new[] { package });
+        }
+
+        /// <summary>
+        /// Add packages to all services.
+        /// Works for both symbols and non-symbol packages.
+        /// </summary>
+        public static async Task AddPackages(SleetContext context, IEnumerable<PackageInput> packages)
+        {
+            await AddNonSymbolsPackages(context, packages);
+            await AddSymbolsPackages(context, packages);
+        }
+
+        /// <summary>
+        /// Add packages to all services.
+        /// Noops for symbols packages.
+        /// </summary>
+        public static async Task AddNonSymbolsPackages(SleetContext context, IEnumerable<PackageInput> packages)
         {
             var services = GetServices(context);
+            var toAdd = packages.Where(e => !e.IsSymbolsPackage).ToList();
 
             foreach (var service in services)
             {
-                if (package.IsSymbolsPackage)
-                {
-                    var symbolsService = service as ISymbolsAddRemovePackages;
+                await service.AddPackagesAsync(toAdd);
+            }
+        }
 
-                    if (symbolsService != null)
+        /// <summary>
+        /// Add packages to all services.
+        /// Noops for non-symbols packages and when symbols is disabled.
+        /// </summary>
+        public static async Task AddSymbolsPackages(SleetContext context, IEnumerable<PackageInput> packages)
+        {
+            var symbolsEnabled = context.SourceSettings.SymbolsEnabled;
+
+            if (symbolsEnabled)
+            {
+                var services = GetSymbolsServices(context);
+
+                foreach (var package in packages)
+                {
+                    if (package.IsSymbolsPackage)
                     {
-                        await symbolsService.AddSymbolsPackageAsync(package);
+                        foreach (var symbolsService in services)
+                        {
+                            await symbolsService.AddSymbolsPackageAsync(package);
+                        }
                     }
                 }
-                else
-                {
-                    await service.AddPackageAsync(package);
-                }
             }
+        }
+
+        /// <summary>
+        /// Remove both the symbols and non-symbols package from all services.
+        /// Avoid removing both the symbols and non-symbols packages, this should only
+        /// remove the package we are going to replace.
+        /// </summary>
+        public static async Task RemovePackages(SleetContext context, IEnumerable<PackageInput> packages)
+        {
+            var nonSymbols = packages.Where(e => !e.IsSymbolsPackage).Select(e => e.Identity).ToList();
+            var symbols = packages.Where(e => e.IsSymbolsPackage).Select(e => e.Identity).ToList();
+
+            await RemoveNonSymbolsPackages(context, nonSymbols);
+            await RemoveSymbolsPackages(context, symbols);
         }
 
         /// <summary>
@@ -44,31 +116,55 @@ namespace Sleet
         /// <summary>
         /// Remove a non-symbols package from all services.
         /// </summary>
-        public static async Task RemoveNonSymbolsPackage(SleetContext context, PackageIdentity package)
+        public static Task RemoveNonSymbolsPackage(SleetContext context, PackageIdentity package)
+        {
+            return RemoveNonSymbolsPackages(context, new[] { package });
+        }
+
+        /// <summary>
+        /// Remove a non-symbols package from all services.
+        /// </summary>
+        public static async Task RemoveNonSymbolsPackages(SleetContext context, IEnumerable<PackageIdentity> packages)
         {
             var services = GetServices(context);
 
             foreach (var service in services)
             {
-                await service.RemovePackageAsync(package);
+                await service.RemovePackagesAsync(packages);
             }
         }
 
         /// <summary>
         /// Remove a symbols package from all services.
         /// </summary>
-        public static async Task RemoveSymbolsPackage(SleetContext context, PackageIdentity package)
+        public static Task RemoveSymbolsPackage(SleetContext context, PackageIdentity package)
         {
-            var services = GetServices(context);
+            return RemoveSymbolsPackages(context, new[] { package });
+        }
+
+        /// <summary>
+        /// Remove a symbols package from all services.
+        /// </summary>
+        public static async Task RemoveSymbolsPackages(SleetContext context, IEnumerable<PackageIdentity> packages)
+        {
+            var services = GetSymbolsServices(context);
             var symbolsEnabled = context.SourceSettings.SymbolsEnabled;
 
             if (symbolsEnabled)
             {
-                foreach (var symbolsService in services.Select(e => e as ISymbolsAddRemovePackages).Where(e => e != null))
+                foreach (var package in packages)
                 {
-                    await symbolsService.RemoveSymbolsPackageAsync(package);
+                    foreach (var symbolsService in services)
+                    {
+                        await symbolsService.RemoveSymbolsPackageAsync(package);
+                    }
                 }
             }
+        }
+
+        public static IReadOnlyList<ISymbolsAddRemovePackages> GetSymbolsServices(SleetContext context)
+        {
+            return GetServices(context).Select(e => e as ISymbolsAddRemovePackages).Where(e => e != null).ToList();
         }
 
         public static IReadOnlyList<ISleetService> GetServices(SleetContext context)

--- a/src/SleetLib/def/IAddRemovePackages.cs
+++ b/src/SleetLib/def/IAddRemovePackages.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using NuGet.Packaging.Core;
 
@@ -11,8 +12,18 @@ namespace Sleet
         Task AddPackageAsync(PackageInput packageInput);
 
         /// <summary>
+        /// Add a set of packages to the service.
+        /// </summary>
+        Task AddPackagesAsync(IEnumerable<PackageInput> packageInputs);
+
+        /// <summary>
         /// Remove a package from the service.
         /// </summary>
         Task RemovePackageAsync(PackageIdentity package);
+
+        /// <summary>
+        /// Remove a set of packages from the service.
+        /// </summary>
+        Task RemovePackagesAsync(IEnumerable<PackageIdentity> packages);
     }
 }

--- a/test/Sleet.Test.Common/SleetTestContext.cs
+++ b/test/Sleet.Test.Common/SleetTestContext.cs
@@ -71,18 +71,10 @@ namespace Sleet.Test.Common
         /// </summary>
         public PackageInput GetPackageInput(FileInfo zipFile, bool isSymbols)
         {
-            var reader = new PackageArchiveReader(zipFile.FullName);
-
-            var zip = new ZipArchive(File.OpenRead(zipFile.FullName), ZipArchiveMode.Read, false);
-            var input = new PackageInput(zipFile.FullName, reader.GetIdentity(), isSymbols)
+            using (var reader = new PackageArchiveReader(zipFile.FullName))
             {
-                Zip = zip,
-                Package = reader
-            };
-
-            DisposeItems.Add(input);
-            DisposeItems.Add(reader);
-            return input;
+                return new PackageInput(zipFile.FullName, isSymbols, reader.NuspecReader);
+            }
         }
 
         public Task Commit()

--- a/test/SleetLib.Tests/AddRemoveTests.cs
+++ b/test/SleetLib.Tests/AddRemoveTests.cs
@@ -4,7 +4,6 @@ using System.IO.Compression;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
-using NuGet.Packaging;
 using NuGet.Packaging.Core;
 using NuGet.Test.Helpers;
 using NuGet.Versioning;
@@ -14,6 +13,168 @@ namespace Sleet.Test
 {
     public class AddRemoveTests
     {
+        [Fact]
+        public async Task AddRemove_AddManyPackagesThenRemoveSome()
+        {
+            // Arrange
+            using (var packagesFolder = new TestFolder())
+            using (var target = new TestFolder())
+            using (var cache = new LocalCache())
+            {
+                var log = new TestLogger();
+                var fileSystem = new PhysicalFileSystem(cache, UriUtility.CreateUri(target.Root));
+                var settings = new LocalSettings();
+
+                var context = new SleetContext()
+                {
+                    Token = CancellationToken.None,
+                    LocalSettings = settings,
+                    Log = log,
+                    Source = fileSystem,
+                    SourceSettings = new FeedSettings()
+                    {
+                        CatalogEnabled = true,
+                        SymbolsEnabled = true
+                    }
+                };
+
+                var identities = new HashSet<PackageIdentity>();
+                var ids = new[] { "a", "b", "c", "d" };
+
+                foreach (var id in ids)
+                {
+                    for (var i = 0; i < 50; i++)
+                    {
+                        var testPackage = new TestNupkg(id, $"{i}.0.0");
+                        var zipFile = testPackage.Save(packagesFolder.Root);
+                        identities.Add(new PackageIdentity(testPackage.Nuspec.Id, NuGetVersion.Parse(testPackage.Nuspec.Version)));
+                    }
+                }
+
+                var catalog = new Catalog(context);
+                var registration = new Registrations(context);
+                var packageIndex = new PackageIndex(context);
+                var search = new Search(context);
+                var autoComplete = new AutoComplete(context);
+
+                await InitCommand.InitAsync(context);
+                await PushCommand.RunAsync(context.LocalSettings, context.Source, new List<string>() { packagesFolder.Root }, false, false, context.Log);
+
+                // Act
+                // run delete command
+                await DeleteCommand.RunAsync(context.LocalSettings, context.Source, "b", null, "removing", false, context.Log);
+
+                var validateOutput = await ValidateCommand.RunAsync(context.LocalSettings, context.Source, context.Log);
+
+                // read output
+                var catalogEntries = await catalog.GetIndexEntriesAsync();
+                var catalogExistingEntries = await catalog.GetExistingPackagesIndexAsync();
+                var catalogPackages = await catalog.GetPackagesAsync();
+
+                var regPackages = new HashSet<PackageIdentity>();
+
+                foreach (var id in ids)
+                {
+                    regPackages.UnionWith(await registration.GetPackagesByIdAsync(id));
+                }
+
+                var indexPackages = await packageIndex.GetPackagesAsync();
+                var searchPackages = await search.GetPackagesAsync();
+                var autoCompletePackages = await autoComplete.GetPackageIds();
+
+                // Assert
+                Assert.True(validateOutput);
+                Assert.Equal(identities.Count + 50, catalogEntries.Count);
+                Assert.Equal(identities.Count - 50, catalogExistingEntries.Count);
+                regPackages.Count.Should().Be(identities.Count - 50);
+                Assert.Equal(identities.Count - 50, indexPackages.Count);
+                Assert.Equal(identities.Count - 50, searchPackages.Count);
+                Assert.Equal(ids.Length - 1, autoCompletePackages.Count);
+            }
+        }
+
+        [Fact]
+        public async Task AddRemove_AddManyPackages()
+        {
+            // Arrange
+            using (var packagesFolder = new TestFolder())
+            using (var target = new TestFolder())
+            using (var cache = new LocalCache())
+            {
+                var log = new TestLogger();
+                var fileSystem = new PhysicalFileSystem(cache, UriUtility.CreateUri(target.Root));
+                var settings = new LocalSettings();
+
+                var context = new SleetContext()
+                {
+                    Token = CancellationToken.None,
+                    LocalSettings = settings,
+                    Log = log,
+                    Source = fileSystem,
+                    SourceSettings = new FeedSettings()
+                    {
+                        CatalogEnabled = true,
+                        SymbolsEnabled = true
+                    }
+                };
+
+                var identities = new HashSet<PackageIdentity>();
+                var ids = new[] { "a", "b", "c", "d" };
+
+                foreach (var id in ids)
+                {
+                    for (var i = 0; i < 50; i++)
+                    {
+                        var testPackage = new TestNupkg(id, $"{i}.0.0");
+                        var zipFile = testPackage.Save(packagesFolder.Root);
+                        identities.Add(new PackageIdentity(testPackage.Nuspec.Id, NuGetVersion.Parse(testPackage.Nuspec.Version)));
+                    }
+                }
+
+                var catalog = new Catalog(context);
+                var registration = new Registrations(context);
+                var packageIndex = new PackageIndex(context);
+                var search = new Search(context);
+                var autoComplete = new AutoComplete(context);
+
+                // Act
+                // run commands
+                await InitCommand.InitAsync(context);
+                await PushCommand.RunAsync(context.LocalSettings, context.Source, new List<string>() { packagesFolder.Root }, false, false, context.Log);
+                var validateOutput = await ValidateCommand.RunAsync(context.LocalSettings, context.Source, context.Log);
+
+                // read outputs
+                var catalogEntries = await catalog.GetIndexEntriesAsync();
+                var catalogExistingEntries = await catalog.GetExistingPackagesIndexAsync();
+                var catalogPackages = await catalog.GetPackagesAsync();
+
+                var regPackages = new HashSet<PackageIdentity>();
+
+                foreach (var id in ids)
+                {
+                    regPackages.UnionWith(await registration.GetPackagesByIdAsync(id));
+                }
+
+                var indexPackages = await packageIndex.GetPackagesAsync();
+                var searchPackages = await search.GetPackagesAsync();
+                var autoCompletePackages = await autoComplete.GetPackageIds();
+
+                // Assert
+                Assert.True(validateOutput);
+                Assert.Equal(identities.Count, catalogEntries.Count);
+                Assert.Equal(identities.Count, catalogExistingEntries.Count);
+                regPackages.Count.Should().Be(identities.Count);
+                Assert.Equal(identities.Count, indexPackages.Count);
+                Assert.Equal(identities.Count, searchPackages.Count);
+                Assert.Equal(ids.Length, autoCompletePackages.Count);
+
+                foreach (var entry in catalogEntries)
+                {
+                    Assert.Equal(SleetOperation.Add, entry.Operation);
+                }
+            }
+        }
+
         [Fact]
         public async Task AddRemove_AddNonNormalizedPackageAsync()
         {
@@ -43,11 +204,7 @@ namespace Sleet.Test
                 var zipFile = testPackage.Save(packagesFolder.Root);
                 using (var zip = new ZipArchive(File.OpenRead(zipFile.FullName), ZipArchiveMode.Read, false))
                 {
-                    var input = new PackageInput(zipFile.FullName, new PackageIdentity("packageA", NuGetVersion.Parse("1.0.0")), false)
-                    {
-                        Zip = zip,
-                        Package = new PackageArchiveReader(zip)
-                    };
+                    var input = PackageInput.Create(zipFile.FullName);
 
                     var catalog = new Catalog(context);
                     var registration = new Registrations(context);
@@ -117,11 +274,7 @@ namespace Sleet.Test
                 var zipFile = testPackage.Save(packagesFolder.Root);
                 using (var zip = new ZipArchive(File.OpenRead(zipFile.FullName), ZipArchiveMode.Read, false))
                 {
-                    var input = new PackageInput(zipFile.FullName, new PackageIdentity("packageA", NuGetVersion.Parse("1.0.0")), false)
-                    {
-                        Zip = zip,
-                        Package = new PackageArchiveReader(zip)
-                    };
+                    var input = PackageInput.Create(zipFile.FullName);
 
                     var catalog = new Catalog(context);
                     var registration = new Registrations(context);
@@ -191,11 +344,7 @@ namespace Sleet.Test
                 var zipFile = testPackage.Save(packagesFolder.Root);
                 using (var zip = new ZipArchive(File.OpenRead(zipFile.FullName), ZipArchiveMode.Read, false))
                 {
-                    var input = new PackageInput(zipFile.FullName, new PackageIdentity("packageA", NuGetVersion.Parse("1.0.0")), false)
-                    {
-                        Zip = zip,
-                        Package = new PackageArchiveReader(zip)
-                    };
+                    var input = PackageInput.Create(zipFile.FullName);
 
                     var catalog = new Catalog(context);
                     var registration = new Registrations(context);
@@ -266,11 +415,7 @@ namespace Sleet.Test
                 var zipFile = testPackage.Save(packagesFolder.Root);
                 using (var zip = new ZipArchive(File.OpenRead(zipFile.FullName), ZipArchiveMode.Read, false))
                 {
-                    var input = new PackageInput(zipFile.FullName, new PackageIdentity("packageA", NuGetVersion.Parse("1.0.0")), false)
-                    {
-                        Zip = zip,
-                        Package = new PackageArchiveReader(zip)
-                    };
+                    var input = PackageInput.Create(zipFile.FullName);
 
                     var catalog = new Catalog(context);
                     var registration = new Registrations(context);
@@ -491,17 +636,8 @@ namespace Sleet.Test
                 using (var zip1 = new ZipArchive(File.OpenRead(zipFile1.FullName), ZipArchiveMode.Read, false))
                 using (var zip2 = new ZipArchive(File.OpenRead(zipFile2.FullName), ZipArchiveMode.Read, false))
                 {
-                    var input = new PackageInput(zipFile1.FullName, new PackageIdentity("packageA", NuGetVersion.Parse("1.0.0")), false)
-                    {
-                        Zip = zip1,
-                        Package = new PackageArchiveReader(zip1)
-                    };
-
-                    var input2 = new PackageInput(zipFile2.FullName, new PackageIdentity("packageA", NuGetVersion.Parse("1.0.0")), false)
-                    {
-                        Zip = zip2,
-                        Package = new PackageArchiveReader(zip2)
-                    };
+                    var input = PackageInput.Create(zipFile1.FullName);
+                    var input2 = PackageInput.Create(zipFile2.FullName);
 
                     var catalog = new Catalog(context);
                     var registration = new Registrations(context);
@@ -569,17 +705,8 @@ namespace Sleet.Test
                 using (var zip1 = new ZipArchive(File.OpenRead(zipFile1.FullName), ZipArchiveMode.Read, false))
                 using (var zip2 = new ZipArchive(File.OpenRead(zipFile2.FullName), ZipArchiveMode.Read, false))
                 {
-                    var input1 = new PackageInput(zipFile1.FullName, new PackageIdentity("packageA", NuGetVersion.Parse("1.0.0")), false)
-                    {
-                        Zip = zip1,
-                        Package = new PackageArchiveReader(zip1)
-                    };
-
-                    var input2 = new PackageInput(zipFile2.FullName, new PackageIdentity("packageA", NuGetVersion.Parse("1.0.0")), false)
-                    {
-                        Zip = zip2,
-                        Package = new PackageArchiveReader(zip2)
-                    };
+                    var input1 = PackageInput.Create(zipFile1.FullName);
+                    var input2 = PackageInput.Create(zipFile2.FullName);
 
                     var catalog = new Catalog(context);
                     var registration = new Registrations(context);

--- a/test/SleetLib.Tests/CatalogTests.cs
+++ b/test/SleetLib.Tests/CatalogTests.cs
@@ -98,13 +98,9 @@ namespace Sleet.Test
                 var zipFile = testPackage.Save(packagesFolder.Root);
                 using (var zip = new ZipArchive(File.OpenRead(zipFile.FullName), ZipArchiveMode.Read, false))
                 {
-                    var input = new PackageInput(zipFile.FullName, new PackageIdentity("packageA", NuGetVersion.Parse("1.0.0-alpha.1")), false)
-                    {
-                        NupkgUri = UriUtility.CreateUri("http://tempuri.org/flatcontainer/packageA/1.0.0-alpha.1/packageA.1.0.0-alpha.1.nupkg"),
-                        Zip = zip,
-                        Package = new PackageArchiveReader(zip)
-                    };
-
+                    var input = PackageInput.Create(zipFile.FullName);
+                    input.NupkgUri = UriUtility.CreateUri("http://tempuri.org/flatcontainer/packageA/1.0.0-alpha.1/packageA.1.0.0-alpha.1.nupkg");
+                    
                     // Act
                     var actual = await CatalogUtility.CreatePackageDetailsAsync(input, catalog.CatalogBaseURI, context.CommitId, writeFileList: true);
 
@@ -183,13 +179,9 @@ namespace Sleet.Test
                 var zipFile = testPackage.Save(packagesFolder.Root);
                 using (var zip = new ZipArchive(File.OpenRead(zipFile.FullName), ZipArchiveMode.Read, false))
                 {
-                    var input = new PackageInput(zipFile.FullName, new PackageIdentity("packageA", NuGetVersion.Parse("1.0.0")), false)
-                    {
-                        NupkgUri = UriUtility.CreateUri("http://tempuri.org/flatcontainer/packageA/1.0.0/packageA.1.0.0.nupkg"),
-                        Zip = zip,
-                        Package = new PackageArchiveReader(zip)
-                    };
-
+                    var input = PackageInput.Create(zipFile.FullName);
+                    input.NupkgUri = UriUtility.CreateUri("http://tempuri.org/flatcontainer/packageA/1.0.0/packageA.1.0.0.nupkg");
+                    
                     // Act
                     var actual = await CatalogUtility.CreatePackageDetailsAsync(input, catalog.CatalogBaseURI, context.CommitId, writeFileList: true);
 
@@ -262,20 +254,12 @@ namespace Sleet.Test
                 using (var zipA = new ZipArchive(File.OpenRead(zipFileA.FullName), ZipArchiveMode.Read, false))
                 using (var zipB = new ZipArchive(File.OpenRead(zipFileB.FullName), ZipArchiveMode.Read, false))
                 {
-                    var inputA = new PackageInput(zipFileA.FullName, new PackageIdentity("packageA", NuGetVersion.Parse("1.0.0")), false)
-                    {
-                        NupkgUri = UriUtility.CreateUri("http://tempuri.org/flatcontainer/packageA/1.0.0/packageA.1.0.0.nupkg"),
-                        Zip = zipA,
-                        Package = new PackageArchiveReader(zipA)
-                    };
+                    var inputA = PackageInput.Create(zipFileA.FullName);
+                    inputA.NupkgUri = UriUtility.CreateUri("http://tempuri.org/flatcontainer/packageA/1.0.0/packageA.1.0.0.nupkg");
 
-                    var inputB = new PackageInput(zipFileB.FullName, new PackageIdentity("packageB", NuGetVersion.Parse("1.0.0")), false)
-                    {
-                        NupkgUri = UriUtility.CreateUri("http://tempuri.org/flatcontainer/packageB/1.0.0/packageB.1.0.0.nupkg"),
-                        Zip = zipB,
-                        Package = new PackageArchiveReader(zipB)
-                    };
-
+                    var inputB = PackageInput.Create(zipFileB.FullName);
+                    inputB.NupkgUri = UriUtility.CreateUri("http://tempuri.org/flatcontainer/packageB/1.0.0/packageB.1.0.0.nupkg");
+                    
                     // Act
                     await catalog.AddPackageAsync(inputA);
                     await catalog.AddPackageAsync(inputB);

--- a/test/SleetLib.Tests/FeedTests.cs
+++ b/test/SleetLib.Tests/FeedTests.cs
@@ -59,11 +59,7 @@ namespace Sleet.Test
                 var zipFile = testPackage.Save(packagesFolder.Root);
                 using (var zip = new ZipArchive(File.OpenRead(zipFile.FullName), ZipArchiveMode.Read, false))
                 {
-                    var input = new PackageInput(zipFile.FullName, new PackageIdentity("packageA", NuGetVersion.Parse("1.0.0")), false)
-                    {
-                        Zip = zip,
-                        Package = new PackageArchiveReader(zip)
-                    };
+                    var input = PackageInput.Create(zipFile.FullName);
 
                     var catalog = new Catalog(context);
                     var registration = new Registrations(context);

--- a/test/SleetLib.Tests/PushCommandTests.cs
+++ b/test/SleetLib.Tests/PushCommandTests.cs
@@ -63,11 +63,7 @@ namespace SleetLib.Tests
 
                 using (var zip = new ZipArchive(File.OpenRead(zipFile.FullName), ZipArchiveMode.Read, false))
                 {
-                    var input = new PackageInput(zipFile.FullName, new PackageIdentity("packageA", NuGetVersion.Parse("1.0.0")), false)
-                    {
-                        Zip = zip,
-                        Package = new PackageArchiveReader(zip)
-                    };
+                    var input = PackageInput.Create(zipFile.FullName);
 
                     var catalog = new Catalog(context);
                     var registration = new Registrations(context);

--- a/test/SleetLib.Tests/SleetTestContext.cs
+++ b/test/SleetLib.Tests/SleetTestContext.cs
@@ -74,13 +74,8 @@ namespace SleetLib.Tests
             var reader = new PackageArchiveReader(zipFile.FullName);
 
             var zip = new ZipArchive(File.OpenRead(zipFile.FullName), ZipArchiveMode.Read, false);
-            var input = new PackageInput(zipFile.FullName, reader.GetIdentity(), isSymbols)
-            {
-                Zip = zip,
-                Package = reader
-            };
+            var input = PackageInput.Create(zipFile.FullName);
 
-            DisposeItems.Add(input);
             DisposeItems.Add(reader);
             return input;
         }


### PR DESCRIPTION
* Improve performance by adding multiple packages at a time to a service, this will reduce the number of file read/writes.
* Run operations in parallel within a service where possible
* Create package readers before locking the feed

Related: https://github.com/emgarten/Sleet/issues/46