### PR TITLE
Add support for relative 'path' setting when using local repository type

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,5 +1,8 @@
 # Release Notes
 
+## 2.3.36
+* Path property in sleet.json can now be a relative path for local feeds
+
 ## 2.3.35
 * Performance improvements, packages are added in batch to reduce the number of file read/writes.
 * Add/removes within a service are done in parallel where possible.

--- a/src/SleetLib/FileSystem/FileSystemFactory.cs
+++ b/src/SleetLib/FileSystem/FileSystemFactory.cs
@@ -38,7 +38,9 @@ namespace Sleet
                         var feedSubPath = JsonUtility.GetValueCaseInsensitive(sourceEntry, "feedSubPath");
                         var type = JsonUtility.GetValueCaseInsensitive(sourceEntry, "type")?.ToLowerInvariant();
 
-                        var pathUri = path != null ? UriUtility.EnsureTrailingSlash(UriUtility.CreateUri(path)) : null;
+                        var absolutePath = path != null && type == "local" ? UriUtility.GetAbsolutePath(path, settings.Path) : null;
+
+                        var pathUri = path != null ? UriUtility.EnsureTrailingSlash(UriUtility.CreateUri(absolutePath)) : null;
                         var baseUri = baseURIString != null ? UriUtility.EnsureTrailingSlash(UriUtility.CreateUri(baseURIString)) : pathUri;
 
                         if (type == "local")

--- a/src/SleetLib/FileSystem/FileSystemFactory.cs
+++ b/src/SleetLib/FileSystem/FileSystemFactory.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 using System.Linq;
 #if !SLEETLEGACY
 using Amazon;
@@ -6,6 +7,7 @@ using Amazon.S3;
 #endif
 using Microsoft.WindowsAzure.Storage;
 using Newtonsoft.Json.Linq;
+using NuGetUriUtility = NuGet.Common.UriUtility;
 
 namespace Sleet
 {
@@ -38,9 +40,25 @@ namespace Sleet
                         var feedSubPath = JsonUtility.GetValueCaseInsensitive(sourceEntry, "feedSubPath");
                         var type = JsonUtility.GetValueCaseInsensitive(sourceEntry, "type")?.ToLowerInvariant();
 
-                        var absolutePath = path != null && type == "local" ? UriUtility.GetAbsolutePath(path, settings.Path) : null;
+                        string absolutePath;
+                        if (path != null && type == "local")
+                        {
+                            if (settings.Path == null && !Path.IsPathRooted(path))
+                            {
+                                throw new ArgumentException("Cannot use a relative 'path' without a settings.json file.");
+                            }
 
-                        var pathUri = path != null ? UriUtility.EnsureTrailingSlash(UriUtility.CreateUri(absolutePath)) : null;
+                            var nonEmptyPath = path == "" ? "." : path;
+
+                            var settingsDir = Path.GetDirectoryName(settings.Path);
+                            absolutePath = NuGetUriUtility.GetAbsolutePath(settingsDir, nonEmptyPath);
+                        }
+                        else
+                        {
+                            absolutePath = path;
+                        }
+
+                        var pathUri = absolutePath != null ? UriUtility.EnsureTrailingSlash(UriUtility.CreateUri(absolutePath)) : null;
                         var baseUri = baseURIString != null ? UriUtility.EnsureTrailingSlash(UriUtility.CreateUri(baseURIString)) : pathUri;
 
                         if (type == "local")

--- a/src/SleetLib/FileSystem/FileSystemFactory.cs
+++ b/src/SleetLib/FileSystem/FileSystemFactory.cs
@@ -43,14 +43,14 @@ namespace Sleet
                         string absolutePath;
                         if (path != null && type == "local")
                         {
-                            if (settings.Path == null && !Path.IsPathRooted(path))
+                            if (settings.Path == null && !Path.IsPathRooted(NuGetUriUtility.GetLocalPath(path)))
                             {
                                 throw new ArgumentException("Cannot use a relative 'path' without a settings.json file.");
                             }
 
                             var nonEmptyPath = path == "" ? "." : path;
 
-                            var settingsDir = Path.GetDirectoryName(settings.Path);
+                            var settingsDir = Path.GetDirectoryName(NuGetUriUtility.GetLocalPath(settings.Path));
                             absolutePath = NuGetUriUtility.GetAbsolutePath(settingsDir, nonEmptyPath);
                         }
                         else

--- a/src/SleetLib/LocalSettings.cs
+++ b/src/SleetLib/LocalSettings.cs
@@ -13,6 +13,11 @@ namespace Sleet
         public JObject Json { get; set; } = new JObject();
 
         /// <summary>
+        /// Path of the sleet.json file
+        /// </summary>
+        public string Path { get; set; }
+
+        /// <summary>
         /// Feed lock wait time.
         /// config/feedLockTimeoutMinutes
         /// </summary>
@@ -20,9 +25,15 @@ namespace Sleet
 
         public static LocalSettings Load(JObject json)
         {
+            return Load(json, null);
+        }
+
+        public static LocalSettings Load(JObject json, string path)
+        {
             return new LocalSettings()
             {
                 Json = json,
+                Path = path,
                 FeedLockTimeout = GetFeedLockTimeout(json)
             };
         }
@@ -44,7 +55,7 @@ namespace Sleet
                     // Resolve tokens in the json
                     SettingsUtility.ResolveTokensInSettingsJson(json, mappings);
 
-                    return Load(json);
+                    return Load(json, path);
                 }
                 else if (!string.IsNullOrEmpty(path))
                 {

--- a/src/SleetLib/Utility/UriUtility.cs
+++ b/src/SleetLib/Utility/UriUtility.cs
@@ -186,21 +186,5 @@ namespace Sleet
 
             return uri;
         }
-
-        public static string GetAbsolutePath(string path, string settingsPath)
-        {
-            if (Path.IsPathRooted(path))
-            {
-                return path;
-            }
-
-            if (settingsPath == null)
-            {
-                throw new ArgumentException("Cannot use a relative 'path' without a settings.json file.");
-            }
-
-            var settingsDir = Path.GetDirectoryName(settingsPath);
-            return Path.GetFullPath(Path.Combine(settingsDir, path));
-        }
     }
 }

--- a/src/SleetLib/Utility/UriUtility.cs
+++ b/src/SleetLib/Utility/UriUtility.cs
@@ -186,5 +186,21 @@ namespace Sleet
 
             return uri;
         }
+
+        public static string GetAbsolutePath(string path, string settingsPath)
+        {
+            if (Path.IsPathRooted(path))
+            {
+                return path;
+            }
+
+            if (settingsPath == null)
+            {
+                throw new ArgumentException("Cannot use a relative 'path' without a settings.json file.");
+            }
+
+            var settingsDir = Path.GetDirectoryName(settingsPath);
+            return Path.GetFullPath(Path.Combine(settingsDir, path));
+        }
     }
 }

--- a/test/Sleet.Integration.Tests/LocalFeedTests.cs
+++ b/test/Sleet.Integration.Tests/LocalFeedTests.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using FluentAssertions;
+using NuGet.Test.Helpers;
+using Sleet.Test;
+using Xunit;
+
+namespace Sleet.Integration.Test
+{
+    public class LocalFeedTests
+    {
+        [Fact]
+        public async Task LocalFeed_RelativePath()
+        {
+            using (var target = new TestFolder())
+            using (var cache = new LocalCache())
+            {
+                var baseUri = UriUtility.CreateUri("https://localhost:8080/testFeed/");
+
+                var log = new TestLogger();
+
+                var sleetConfig = TestUtility.CreateConfigWithLocal("local", "output", baseUri.AbsoluteUri);
+
+                var sleetConfigPath = Path.Combine(target.Root, "sleet.config");
+                await JsonUtility.SaveJsonAsync(new FileInfo(sleetConfigPath), sleetConfig);
+
+                var settings = LocalSettings.Load(sleetConfigPath);
+                var fileSystem = FileSystemFactory.CreateFileSystem(settings, cache, "local") as PhysicalFileSystem;
+
+                fileSystem.Should().NotBeNull();
+                fileSystem.LocalRoot.Should().Be(Path.Combine(target.Root, "output") + Path.DirectorySeparatorChar);
+            }
+        }
+    }
+}

--- a/test/SleetLib.Tests/UriUtilityTests.cs
+++ b/test/SleetLib.Tests/UriUtilityTests.cs
@@ -1,6 +1,4 @@
 using System;
-using FluentAssertions;
-using Sleet.Test.Common;
 using Xunit;
 
 namespace Sleet.Test

--- a/test/SleetLib.Tests/UriUtilityTests.cs
+++ b/test/SleetLib.Tests/UriUtilityTests.cs
@@ -1,5 +1,6 @@
 using System;
 using FluentAssertions;
+using Sleet.Test.Common;
 using Xunit;
 
 namespace Sleet.Test
@@ -49,7 +50,7 @@ namespace Sleet.Test
             Assert.Equal(expected, UriUtility.EnsureTrailingSlash(new Uri(uri)).AbsoluteUri);
         }
 
-        [Theory]
+        [WindowsTheory]
         [InlineData(@".\", @"c:\otherPath\sleet.json", @"c:\otherPath\")]
         [InlineData(@".", @"c:\otherPath\sleet.json", @"c:\otherPath")]
         [InlineData(@"", @"c:\otherPath\sleet.json", @"c:\otherPath")]

--- a/test/SleetLib.Tests/UriUtilityTests.cs
+++ b/test/SleetLib.Tests/UriUtilityTests.cs
@@ -1,4 +1,5 @@
-﻿using System;
+using System;
+using FluentAssertions;
 using Xunit;
 
 namespace Sleet.Test
@@ -46,6 +47,36 @@ namespace Sleet.Test
         public void UriUtility_EnsureTrailingSlash(string uri, string expected)
         {
             Assert.Equal(expected, UriUtility.EnsureTrailingSlash(new Uri(uri)).AbsoluteUri);
+        }
+
+        [Theory]
+        [InlineData(@".\", @"c:\otherPath\sleet.json", @"c:\otherPath\")]
+        [InlineData(@".", @"c:\otherPath\sleet.json", @"c:\otherPath")]
+        [InlineData(@"", @"c:\otherPath\sleet.json", @"c:\otherPath")]
+        [InlineData(@"singleSubFolder", @"c:\otherPath\sleet.json", @"c:\otherPath\singleSubFolder")]
+        [InlineData(@"nestedSubFolder\a", @"c:\otherPath\sleet.json", @"c:\otherPath\nestedSubFolder\a")]
+        [InlineData(@"c:\absolutePath", @"c:\otherPath\sleet.json", @"c:\absolutePath")]
+        public void UriUtility_GetAbsolutePath(string path, string settingsPath, string expected)
+        {
+            Assert.Equal(expected, UriUtility.GetAbsolutePath(path, settingsPath));
+        }
+
+        [Fact]
+        public void UriUtility_ThrowsIfGetAbosolutePathWithNoSettingsFile()
+        {
+            Exception ex = null;
+
+            try
+            {
+                UriUtility.GetAbsolutePath("", null);
+            }
+            catch (Exception e)
+            {
+                ex = e;
+            }
+
+            ex.Should().NotBeNull();
+            ex.Message.Should().Be("Cannot use a relative 'path' without a settings.json file.");
         }
     }
 }

--- a/test/SleetLib.Tests/UriUtilityTests.cs
+++ b/test/SleetLib.Tests/UriUtilityTests.cs
@@ -49,35 +49,5 @@ namespace Sleet.Test
         {
             Assert.Equal(expected, UriUtility.EnsureTrailingSlash(new Uri(uri)).AbsoluteUri);
         }
-
-        [WindowsTheory]
-        [InlineData(@".\", @"c:\otherPath\sleet.json", @"c:\otherPath\")]
-        [InlineData(@".", @"c:\otherPath\sleet.json", @"c:\otherPath")]
-        [InlineData(@"", @"c:\otherPath\sleet.json", @"c:\otherPath")]
-        [InlineData(@"singleSubFolder", @"c:\otherPath\sleet.json", @"c:\otherPath\singleSubFolder")]
-        [InlineData(@"nestedSubFolder\a", @"c:\otherPath\sleet.json", @"c:\otherPath\nestedSubFolder\a")]
-        [InlineData(@"c:\absolutePath", @"c:\otherPath\sleet.json", @"c:\absolutePath")]
-        public void UriUtility_GetAbsolutePath(string path, string settingsPath, string expected)
-        {
-            Assert.Equal(expected, UriUtility.GetAbsolutePath(path, settingsPath));
-        }
-
-        [Fact]
-        public void UriUtility_ThrowsIfGetAbosolutePathWithNoSettingsFile()
-        {
-            Exception ex = null;
-
-            try
-            {
-                UriUtility.GetAbsolutePath("", null);
-            }
-            catch (Exception e)
-            {
-                ex = e;
-            }
-
-            ex.Should().NotBeNull();
-            ex.Message.Should().Be("Cannot use a relative 'path' without a settings.json file.");
-        }
     }
 }


### PR DESCRIPTION
This allows a path relative to the sleet.json file, in a similar way to a local nuget repository can be local to a nuget.config file.

Closes #49