### PR TITLE
Allow client to be created without specifying keys

### DIFF
--- a/src/SleetLib/FileSystem/FileSystemFactory.cs
+++ b/src/SleetLib/FileSystem/FileSystemFactory.cs
@@ -113,10 +113,6 @@ namespace Sleet
                             var bucketName = JsonUtility.GetValueCaseInsensitive(sourceEntry, "bucketName");
                             var region = JsonUtility.GetValueCaseInsensitive(sourceEntry, "region");
 
-                            if (string.IsNullOrEmpty(accessKeyId))
-                                throw new ArgumentException("Missing accessKeyId for Amazon S3 account.");
-                            if (string.IsNullOrEmpty(secretAccessKey))
-                                throw new ArgumentException("Missing secretAccessKey for Amazon S3 account.");
                             if (string.IsNullOrEmpty(bucketName))
                                 throw new ArgumentException("Missing bucketName for Amazon S3 account.");
                             if (string.IsNullOrEmpty(region))
@@ -135,8 +131,8 @@ namespace Sleet
                                 baseUri = pathUri;
                             }
 
-                            var amazonS3Client = new AmazonS3Client(
-                                accessKeyId, secretAccessKey, regionSystemName);
+                            var amazonS3Client = string.IsNullOrEmpty(accessKeyId) ? new AmazonS3Client(regionSystemName)
+                                : new AmazonS3Client(accessKeyId, secretAccessKey, region);
 
                             result = new AmazonS3FileSystem(
                                 cache,


### PR DESCRIPTION
Keeping AWS keys in source files is a practice that should be avoided.  Since the SDK will find and use credentials already configured on a developer or build machine, there is no need to require them in `sleet.config`.  This change proposes to remove that requirement, with backward-compatible support for config files that already contain keys.