### PR TITLE
Encourage AWS profile name rather than keys in sleet.config

### DIFF
--- a/src/SleetLib/Commands/CreateConfigCommand.cs
+++ b/src/SleetLib/Commands/CreateConfigCommand.cs
@@ -74,8 +74,7 @@ namespace Sleet
                         { "type", "s3" },
                         { "bucketName", "bucketname" },
                         { "region", "us-east-1" },
-                        { "accessKeyId", "" },
-                        { "secretAccessKey", "" }
+                        { "profileName", "default" }
                     };
                     break;
             }

--- a/src/SleetLib/FileSystem/FileSystemFactory.cs
+++ b/src/SleetLib/FileSystem/FileSystemFactory.cs
@@ -140,7 +140,7 @@ namespace Sleet
                                 string.IsNullOrEmpty(profileName) ?
                                     new AmazonS3Client(regionSystemName)
                                     : new AmazonS3Client(profile.GetAWSCredentials(null), regionSystemName)
-                                : new AmazonS3Client(accessKeyId, secretAccessKey, region);
+                                : new AmazonS3Client(accessKeyId, secretAccessKey, regionSystemName);
 
                             result = new AmazonS3FileSystem(
                                 cache,


### PR DESCRIPTION
This change removes the `accessKeyId` and `secretAccessKey` elements created by `CreateConfigCommand` and add a new `profileName` key.  It also changes the `AmazonS3Client` constructor used in `FileSystemFactory` to make use of the provided profile if keys aren't provided. This is not a breaking change since keys provided in existing `sleet.json` files will be preferred.
