### PR TITLE
Fixes potential infinite loop while listing Blobs

### DIFF
--- a/src/SleetLib/Commands/CreateConfigCommand.cs
+++ b/src/SleetLib/Commands/CreateConfigCommand.cs
@@ -74,8 +74,7 @@ namespace Sleet
                         { "type", "s3" },
                         { "bucketName", "bucketname" },
                         { "region", "us-east-1" },
-                        { "accessKeyId", "" },
-                        { "secretAccessKey", "" }
+                        { "profileName", "default" }
                     };
                     break;
             }

--- a/src/SleetLib/FileSystem/FileSystemFactory.cs
+++ b/src/SleetLib/FileSystem/FileSystemFactory.cs
@@ -113,10 +113,6 @@ namespace Sleet
                             var bucketName = JsonUtility.GetValueCaseInsensitive(sourceEntry, "bucketName");
                             var region = JsonUtility.GetValueCaseInsensitive(sourceEntry, "region");
 
-                            if (string.IsNullOrEmpty(accessKeyId))
-                                throw new ArgumentException("Missing accessKeyId for Amazon S3 account.");
-                            if (string.IsNullOrEmpty(secretAccessKey))
-                                throw new ArgumentException("Missing secretAccessKey for Amazon S3 account.");
                             if (string.IsNullOrEmpty(bucketName))
                                 throw new ArgumentException("Missing bucketName for Amazon S3 account.");
                             if (string.IsNullOrEmpty(region))
@@ -135,8 +131,8 @@ namespace Sleet
                                 baseUri = pathUri;
                             }
 
-                            var amazonS3Client = new AmazonS3Client(
-                                accessKeyId, secretAccessKey, regionSystemName);
+                            var amazonS3Client = string.IsNullOrEmpty(accessKeyId) ? new AmazonS3Client(regionSystemName)
+                                : new AmazonS3Client(accessKeyId, secretAccessKey, region);
 
                             result = new AmazonS3FileSystem(
                                 cache,

--- a/test/Sleet.Azure.Tests/SubFeedTests.cs
+++ b/test/Sleet.Azure.Tests/SubFeedTests.cs
@@ -178,7 +178,6 @@ namespace Sleet.Azure.Tests
         /// </summary>
         private static async Task<List<Uri>> GetFiles(CloudBlobContainer container)
         {
-            BlobContinuationToken continuationToken = null;
             string prefix = null;
             var useFlatBlobListing = true;
             var blobListingDetails = BlobListingDetails.All;
@@ -187,12 +186,13 @@ namespace Sleet.Azure.Tests
             // Return all files except feedlock
             var blobs = new List<IListBlobItem>();
 
+            BlobResultSegment result = null;
             do
             {
-                var result = await container.ListBlobsSegmentedAsync(prefix, useFlatBlobListing, blobListingDetails, maxResults, continuationToken, options: null, operationContext: null);
+                result = await container.ListBlobsSegmentedAsync(prefix, useFlatBlobListing, blobListingDetails, maxResults, result?.ContinuationToken, options: null, operationContext: null);
                 blobs.AddRange(result.Results);
             }
-            while (continuationToken != null);
+            while (result.ContinuationToken != null);
 
             // Skip the feed lock, and limit this to the current sub feed.
             return blobs.Select(e => e.Uri).ToList();


### PR DESCRIPTION
It looks like the code for "paging" over a list of blobs using `ListBlobsSegmentedAsync` wasn't quite right.  This patch changes the code to use the continuation token returned with each request, rather than holding on to the original (`null`) value in perpetuity.