### PR TITLE
Removes two constant conditional expressions.

### DIFF
--- a/src/SleetLib/FileSystem/FileSystemFactory.cs
+++ b/src/SleetLib/FileSystem/FileSystemFactory.cs
@@ -27,131 +27,128 @@ namespace Sleet
                 throw new ArgumentException("Invalid config. No sources found.");
             }
 
-            if (sources != null)
+            foreach (var sourceEntry in sources.Select(e => (JObject)e))
             {
-                foreach (var sourceEntry in sources.Select(e => (JObject)e))
+                var sourceName = JsonUtility.GetValueCaseInsensitive(sourceEntry, "name");
+
+                if (source.Equals(sourceName, StringComparison.OrdinalIgnoreCase))
                 {
-                    var sourceName = JsonUtility.GetValueCaseInsensitive(sourceEntry, "name");
+                    var path = JsonUtility.GetValueCaseInsensitive(sourceEntry, "path");
+                    var baseURIString = JsonUtility.GetValueCaseInsensitive(sourceEntry, "baseURI");
+                    var feedSubPath = JsonUtility.GetValueCaseInsensitive(sourceEntry, "feedSubPath");
+                    var type = JsonUtility.GetValueCaseInsensitive(sourceEntry, "type")?.ToLowerInvariant();
 
-                    if (source.Equals(sourceName, StringComparison.OrdinalIgnoreCase))
+                    string absolutePath;
+                    if (path != null && type == "local")
                     {
-                        var path = JsonUtility.GetValueCaseInsensitive(sourceEntry, "path");
-                        var baseURIString = JsonUtility.GetValueCaseInsensitive(sourceEntry, "baseURI");
-                        var feedSubPath = JsonUtility.GetValueCaseInsensitive(sourceEntry, "feedSubPath");
-                        var type = JsonUtility.GetValueCaseInsensitive(sourceEntry, "type")?.ToLowerInvariant();
-
-                        string absolutePath;
-                        if (path != null && type == "local")
+                        if (settings.Path == null && !Path.IsPathRooted(NuGetUriUtility.GetLocalPath(path)))
                         {
-                            if (settings.Path == null && !Path.IsPathRooted(NuGetUriUtility.GetLocalPath(path)))
-                            {
-                                throw new ArgumentException("Cannot use a relative 'path' without a settings.json file.");
-                            }
-
-                            var nonEmptyPath = path == "" ? "." : path;
-
-                            var settingsDir = Path.GetDirectoryName(NuGetUriUtility.GetLocalPath(settings.Path));
-                            absolutePath = NuGetUriUtility.GetAbsolutePath(settingsDir, nonEmptyPath);
-                        }
-                        else
-                        {
-                            absolutePath = path;
+                            throw new ArgumentException("Cannot use a relative 'path' without a settings.json file.");
                         }
 
-                        var pathUri = absolutePath != null ? UriUtility.EnsureTrailingSlash(UriUtility.CreateUri(absolutePath)) : null;
-                        var baseUri = baseURIString != null ? UriUtility.EnsureTrailingSlash(UriUtility.CreateUri(baseURIString)) : pathUri;
+                        var nonEmptyPath = path == "" ? "." : path;
 
-                        if (type == "local")
-                        {
-                            if (pathUri == null)
-                            {
-                                throw new ArgumentException("Missing path for account.");
-                            }
-
-                            result = new PhysicalFileSystem(cache, pathUri, baseUri);
-                        }
-                        else if (type == "azure")
-                        {
-                            var connectionString = JsonUtility.GetValueCaseInsensitive(sourceEntry, "connectionString");
-                            var container = JsonUtility.GetValueCaseInsensitive(sourceEntry, "container");
-
-                            if (string.IsNullOrEmpty(connectionString))
-                            {
-                                throw new ArgumentException("Missing connectionString for azure account.");
-                            }
-
-                            if (connectionString.Equals(AzureFileSystem.AzureEmptyConnectionString, StringComparison.OrdinalIgnoreCase))
-                            {
-                                throw new ArgumentException("Invalid connectionString for azure account.");
-                            }
-
-                            if (string.IsNullOrEmpty(container))
-                            {
-                                throw new ArgumentException("Missing container for azure account.");
-                            }
-
-                            var azureAccount = CloudStorageAccount.Parse(connectionString);
-
-                            if (pathUri == null)
-                            {
-                                // Get the default url from the container
-                                pathUri = AzureUtility.GetContainerPath(azureAccount, container);
-                            }
-
-                            if (baseUri == null)
-                            {
-                                baseUri = pathUri;
-                            }
-
-                            result = new AzureFileSystem(cache, pathUri, baseUri, azureAccount, container, feedSubPath);
-                        }
-#if !SLEETLEGACY
-                        else if (type == "s3")
-                        {
-                            var accessKeyId = JsonUtility.GetValueCaseInsensitive(sourceEntry, "accessKeyId");
-                            var secretAccessKey = JsonUtility.GetValueCaseInsensitive(sourceEntry, "secretAccessKey");
-                            var profileName = JsonUtility.GetValueCaseInsensitive(sourceEntry, "profileName");
-                            var bucketName = JsonUtility.GetValueCaseInsensitive(sourceEntry, "bucketName");
-                            var region = JsonUtility.GetValueCaseInsensitive(sourceEntry, "region");
-
-                            if (string.IsNullOrEmpty(profileName) && string.IsNullOrEmpty(accessKeyId))
-                                throw new ArgumentException("Must provide a profileName or accessKeyId and secretAccessKey for Amazon S3 account.");
-                            if (string.IsNullOrEmpty(bucketName))
-                                throw new ArgumentException("Missing bucketName for Amazon S3 account.");
-                            if (string.IsNullOrEmpty(region))
-                                throw new ArgumentException("Missing region for Amazon S3 account.");
-
-                            var regionSystemName = RegionEndpoint.GetBySystemName(region);
-                            if (!new Amazon.Runtime.CredentialManagement.SharedCredentialsFile().TryGetProfile(profileName, out var profile))
-                                throw new ArgumentException($"The specified profile {profileName} could not be found.");
-
-                            if (pathUri == null)
-                            {
-                                // Find the default path
-                                pathUri = AmazonS3Utility.GetBucketPath(bucketName, regionSystemName.SystemName);
-                            }
-
-                            if (baseUri == null)
-                            {
-                                baseUri = pathUri;
-                            }
-
-                            var amazonS3Client = string.IsNullOrEmpty(accessKeyId) ?
-                                string.IsNullOrEmpty(profileName) ?
-                                    new AmazonS3Client(regionSystemName)
-                                    : new AmazonS3Client(profile.GetAWSCredentials(null), regionSystemName)
-                                : new AmazonS3Client(accessKeyId, secretAccessKey, regionSystemName);
-
-                            result = new AmazonS3FileSystem(
-                                cache,
-                                pathUri,
-                                baseUri,
-                                amazonS3Client,
-                                bucketName,
-                                feedSubPath);
-                        }
-#endif
+                        var settingsDir = Path.GetDirectoryName(NuGetUriUtility.GetLocalPath(settings.Path));
+                        absolutePath = NuGetUriUtility.GetAbsolutePath(settingsDir, nonEmptyPath);
                     }
+                    else
+                    {
+                        absolutePath = path;
+                    }
+
+                    var pathUri = absolutePath != null ? UriUtility.EnsureTrailingSlash(UriUtility.CreateUri(absolutePath)) : null;
+                    var baseUri = baseURIString != null ? UriUtility.EnsureTrailingSlash(UriUtility.CreateUri(baseURIString)) : pathUri;
+
+                    if (type == "local")
+                    {
+                        if (pathUri == null)
+                        {
+                            throw new ArgumentException("Missing path for account.");
+                        }
+
+                        result = new PhysicalFileSystem(cache, pathUri, baseUri);
+                    }
+                    else if (type == "azure")
+                    {
+                        var connectionString = JsonUtility.GetValueCaseInsensitive(sourceEntry, "connectionString");
+                        var container = JsonUtility.GetValueCaseInsensitive(sourceEntry, "container");
+
+                        if (string.IsNullOrEmpty(connectionString))
+                        {
+                            throw new ArgumentException("Missing connectionString for azure account.");
+                        }
+
+                        if (connectionString.Equals(AzureFileSystem.AzureEmptyConnectionString, StringComparison.OrdinalIgnoreCase))
+                        {
+                            throw new ArgumentException("Invalid connectionString for azure account.");
+                        }
+
+                        if (string.IsNullOrEmpty(container))
+                        {
+                            throw new ArgumentException("Missing container for azure account.");
+                        }
+
+                        var azureAccount = CloudStorageAccount.Parse(connectionString);
+
+                        if (pathUri == null)
+                        {
+                            // Get the default url from the container
+                            pathUri = AzureUtility.GetContainerPath(azureAccount, container);
+                        }
+
+                        if (baseUri == null)
+                        {
+                            baseUri = pathUri;
+                        }
+
+                        result = new AzureFileSystem(cache, pathUri, baseUri, azureAccount, container, feedSubPath);
+                    }
+#if !SLEETLEGACY
+                    else if (type == "s3")
+                    {
+                        var accessKeyId = JsonUtility.GetValueCaseInsensitive(sourceEntry, "accessKeyId");
+                        var secretAccessKey = JsonUtility.GetValueCaseInsensitive(sourceEntry, "secretAccessKey");
+                        var profileName = JsonUtility.GetValueCaseInsensitive(sourceEntry, "profileName");
+                        var bucketName = JsonUtility.GetValueCaseInsensitive(sourceEntry, "bucketName");
+                        var region = JsonUtility.GetValueCaseInsensitive(sourceEntry, "region");
+
+                        if (string.IsNullOrEmpty(profileName) && string.IsNullOrEmpty(accessKeyId))
+                            throw new ArgumentException("Must provide a profileName or accessKeyId and secretAccessKey for Amazon S3 account.");
+                        if (string.IsNullOrEmpty(bucketName))
+                            throw new ArgumentException("Missing bucketName for Amazon S3 account.");
+                        if (string.IsNullOrEmpty(region))
+                            throw new ArgumentException("Missing region for Amazon S3 account.");
+
+                        var regionSystemName = RegionEndpoint.GetBySystemName(region);
+                        if (!new Amazon.Runtime.CredentialManagement.SharedCredentialsFile().TryGetProfile(profileName, out var profile))
+                            throw new ArgumentException($"The specified profile {profileName} could not be found.");
+
+                        if (pathUri == null)
+                        {
+                            // Find the default path
+                            pathUri = AmazonS3Utility.GetBucketPath(bucketName, regionSystemName.SystemName);
+                        }
+
+                        if (baseUri == null)
+                        {
+                            baseUri = pathUri;
+                        }
+
+                        var amazonS3Client = string.IsNullOrEmpty(accessKeyId) ?
+                            string.IsNullOrEmpty(profileName) ?
+                                new AmazonS3Client(regionSystemName)
+                                : new AmazonS3Client(profile.GetAWSCredentials(null), regionSystemName)
+                            : new AmazonS3Client(accessKeyId, secretAccessKey, regionSystemName);
+
+                        result = new AmazonS3FileSystem(
+                            cache,
+                            pathUri,
+                            baseUri,
+                            amazonS3Client,
+                            bucketName,
+                            feedSubPath);
+                    }
+#endif
                 }
             }
 

--- a/src/SleetLib/Utility/UriUtility.cs
+++ b/src/SleetLib/Utility/UriUtility.cs
@@ -81,11 +81,6 @@ namespace Sleet
 
             var root = CreateUri(paths[0]);
 
-            if (paths.Length < 1)
-            {
-                return root;
-            }
-
             return GetPath(root, paths.Skip(1).ToArray());
         }
 


### PR DESCRIPTION
- In UriUtility.cs the check `path.Length == 0`  made at line 77 throws when true.  The subsequent check `path.Length < 1` is then superfluous since we know it isn't.
- In FileSystemFactory.cs the check `sources == null` at line 25 likewise throws when found to be true, making the subsequent check for `sources != null` always true and uneeded.