### PR TITLE
Create a little json for unspecified feed types.

### DIFF
--- a/src/SleetLib/Commands/CreateConfigCommand.cs
+++ b/src/SleetLib/Commands/CreateConfigCommand.cs
@@ -77,6 +77,13 @@ namespace Sleet
                         { "profileName", "default" }
                     };
                     break;
+                case FileSystemStorageType.Unspecified:
+                    storageTemplateJson = new JObject
+                    {
+                        { "name", "myFeed" },
+                        { "type", "" }
+                    };
+                    break;
             }
 
             if (storageTemplateJson != null)


### PR DESCRIPTION
Currently, the command `sleet createconfig` produces output like:
```
{
  "username": "",
  "useremail": "",
  "sources": []
}
```
Which leave the user guessing a bit about what goes in `sources`. It's minor, but helpful to suggest the bare minium starting point for a source:
```
{
  "username": "",
  "useremail": "",
  "sources": [
    {
      "name": "myFeed",
      "type": ""
    }
  ]
}
```