### PR TITLE
Relative local fixes 59

### DIFF
--- a/Sleet.sln
+++ b/Sleet.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27004.2000
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.28531.58
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{98ECD2D1-744F-4DFA-A16A-E13EE596F10C}"
 EndProject

--- a/src/SleetLib/FileSystem/FileSystemFactory.cs
+++ b/src/SleetLib/FileSystem/FileSystemFactory.cs
@@ -48,7 +48,9 @@ namespace Sleet
 
                         var nonEmptyPath = path == "" ? "." : path;
 
-                        var settingsDir = Path.GetDirectoryName(NuGetUriUtility.GetLocalPath(settings.Path));
+                        var absoluteSettingsPath = NuGetUriUtility.GetAbsolutePath(Directory.GetCurrentDirectory(), settings.Path);
+
+                        var settingsDir = Path.GetDirectoryName(absoluteSettingsPath);
                         absolutePath = NuGetUriUtility.GetAbsolutePath(settingsDir, nonEmptyPath);
                     }
                     else

--- a/src/SleetLib/FileSystem/FileSystemFactory.cs
+++ b/src/SleetLib/FileSystem/FileSystemFactory.cs
@@ -43,7 +43,7 @@ namespace Sleet
                     {
                         if (settings.Path == null && !Path.IsPathRooted(NuGetUriUtility.GetLocalPath(path)))
                         {
-                            throw new ArgumentException("Cannot use a relative 'path' without a settings.json file.");
+                            throw new ArgumentException("Cannot use a relative 'path' without a sleet.json file.");
                         }
 
                         var nonEmptyPath = path == "" ? "." : path;

--- a/src/SleetLib/LocalSettings.cs
+++ b/src/SleetLib/LocalSettings.cs
@@ -13,7 +13,7 @@ namespace Sleet
         public JObject Json { get; set; } = new JObject();
 
         /// <summary>
-        /// Path of the sleet.json file
+        /// Absolute path of the sleet.json file
         /// </summary>
         public string Path { get; set; }
 
@@ -48,14 +48,16 @@ namespace Sleet
 
             if (!skipConfig)
             {
-                json = SettingsUtility.GetSleetJsonOrNull(path);
+                var resolvedPath = SettingsUtility.GetSleetJsonPathOrNull(path);
 
-                if (json != null)
+                if (resolvedPath != null)
                 {
+                    json = JObject.Parse(File.ReadAllText(resolvedPath));
+
                     // Resolve tokens in the json
                     SettingsUtility.ResolveTokensInSettingsJson(json, mappings);
 
-                    return Load(json, path);
+                    return Load(json, resolvedPath);
                 }
                 else if (!string.IsNullOrEmpty(path))
                 {

--- a/src/SleetLib/Utility/SettingsUtility.cs
+++ b/src/SleetLib/Utility/SettingsUtility.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Text;
 using Newtonsoft.Json.Linq;
 using NuGet.Common;
+using NuGetUriUtility = NuGet.Common.UriUtility;
 
 namespace Sleet
 {
@@ -202,7 +203,7 @@ namespace Sleet
         /// <summary>
         /// Find sleet.json at the given path or search upwards from the current directory.
         /// </summary>
-        public static JObject GetSleetJsonOrNull(string path)
+        public static string GetSleetJsonPathOrNull(string path)
         {
             if (string.IsNullOrEmpty(path))
             {
@@ -214,7 +215,9 @@ namespace Sleet
                 return null;
             }
 
-            return JObject.Parse(File.ReadAllText(path));
+            var absolutePath = NuGetUriUtility.GetAbsolutePath(Directory.GetCurrentDirectory(), path);
+
+            return absolutePath;
         }
 
         /// <summary>

--- a/test/Sleet.Integration.Tests/LocalFeedTests.cs
+++ b/test/Sleet.Integration.Tests/LocalFeedTests.cs
@@ -34,5 +34,42 @@ namespace Sleet.Integration.Test
                 fileSystem.LocalRoot.Should().Be(Path.Combine(target.Root, "output") + Path.DirectorySeparatorChar);
             }
         }
+
+        [Fact]
+        public async Task LocalFeed_RelativePath_DefaultSleetJson()
+        {
+            var originalWorkingDir = Directory.GetCurrentDirectory();
+
+            using (var target = new TestFolder())
+            using (var cache = new LocalCache())
+            {
+                var baseUri = UriUtility.CreateUri("https://localhost:8080/testFeed/");
+
+                var log = new TestLogger();
+
+                var sleetConfig = TestUtility.CreateConfigWithLocal("local", "output", baseUri.AbsoluteUri);
+
+                var sleetConfigPath = Path.Combine(target.Root, "sleet.json");
+                await JsonUtility.SaveJsonAsync(new FileInfo(sleetConfigPath), sleetConfig);
+
+
+                try
+                {
+                    Directory.SetCurrentDirectory(target.Root);
+
+                    //Load sleet.json file from working directory
+                    var settings = LocalSettings.Load(path: null);
+                    var fileSystem = FileSystemFactory.CreateFileSystem(settings, cache, "local") as PhysicalFileSystem;
+
+                    fileSystem.Should().NotBeNull();
+                    fileSystem.LocalRoot.Should().Be(Path.Combine(target.Root, "output") + Path.DirectorySeparatorChar);
+
+                }
+                finally
+                {
+                    Directory.SetCurrentDirectory(originalWorkingDir);
+                }
+            }
+        }
     }
 }

--- a/test/SleetLib.Tests/FeedTests.cs
+++ b/test/SleetLib.Tests/FeedTests.cs
@@ -163,7 +163,7 @@ namespace SleetLib.Tests
             }
 
             ex.Should().NotBeNull();
-            ex.Message.Should().Be("Cannot use a relative 'path' without a settings.json file.");
+            ex.Message.Should().Be("Cannot use a relative 'path' without a sleet.json file.");
         }
     }
 }

--- a/test/SleetLib.Tests/FeedTests.cs
+++ b/test/SleetLib.Tests/FeedTests.cs
@@ -124,8 +124,14 @@ namespace SleetLib.Tests
         [InlineData(@"file:///c:/configPath/sleet.json", @"", @"c:\configPath\")]
         [InlineData(@"file:///c:/configPath/sleet.json", @"singleSubFolder", @"c:\configPath\singleSubFolder\")]
         [InlineData(@"file:///c:/configPath/sleet.json", @"nestedSubFolder\a", @"c:\configPath\nestedSubFolder\a\")]
+        [InlineData(@"sleet.json", @"", @"{workingDir}\")]
+        [InlineData(@"sleet.json", @".\", @"{workingDir}\")]
+        [InlineData(@"sleet.json", @"singleSubFolder", @"{workingDir}\singleSubFolder\")]
+        [InlineData(@"sleet.json", @"nestedSubFolder\a", @"{workingDir}\nestedSubFolder\a\")]
         public void Feed_LocalTypeSupportsRelativePath(string configPath, string outputPath, string expected)
         {
+            var expectedFull = expected.Replace("{workingDir}", Directory.GetCurrentDirectory());
+
             using (var cache = new LocalCache())
             {
                 var baseUri = UriUtility.CreateUri("https://localhost:8080/testFeed/");
@@ -136,7 +142,7 @@ namespace SleetLib.Tests
                 var fileSystem = FileSystemFactory.CreateFileSystem(settings, cache, "local") as PhysicalFileSystem;
 
                 Assert.NotNull(fileSystem);
-                Assert.Equal(expected, fileSystem.LocalRoot);
+                Assert.Equal(expectedFull, fileSystem.LocalRoot);
             }
         }
 

--- a/test/SleetLib.Tests/FeedTests.cs
+++ b/test/SleetLib.Tests/FeedTests.cs
@@ -112,18 +112,18 @@ namespace SleetLib.Tests
         }
 
         [WindowsTheory]
-        [InlineData(@"c:\configPath\sleet.config", @".\", @"c:\configPath\")]
-        [InlineData(@"c:\configPath\sleet.config", @".", @"c:\configPath\")]
-        [InlineData(@"c:\configPath\sleet.config", @"", @"c:\configPath\")]
-        [InlineData(@"c:\configPath\sleet.config", @"singleSubFolder", @"c:\configPath\singleSubFolder\")]
-        [InlineData(@"c:\configPath\sleet.config", @"nestedSubFolder\a", @"c:\configPath\nestedSubFolder\a\")]
-        [InlineData(@"c:\configPath\sleet.config", @"c:\absolutePath", @"c:\absolutePath\")]
-        [InlineData(@"\\some-network-share\share\sleet.config", @"singleSubFolder", @"\\some-network-share\share\singleSubFolder\")]
-        [InlineData(@"\\some-network-share\share\sleet.config", @"nestedSubFolder\a", @"\\some-network-share\share\nestedSubFolder\a\")]
-        [InlineData(@"\\some-network-share\share\sleet.config", @".\", @"\\some-network-share\share\")]
-        [InlineData(@"file:///c:/configPath/sleet.config", @"", @"c:\configPath\")]
-        [InlineData(@"file:///c:/configPath/sleet.config", @"singleSubFolder", @"c:\configPath\singleSubFolder\")]
-        [InlineData(@"file:///c:/configPath/sleet.config", @"nestedSubFolder\a", @"c:\configPath\nestedSubFolder\a\")]
+        [InlineData(@"c:\configPath\sleet.json", @".\", @"c:\configPath\")]
+        [InlineData(@"c:\configPath\sleet.json", @".", @"c:\configPath\")]
+        [InlineData(@"c:\configPath\sleet.json", @"", @"c:\configPath\")]
+        [InlineData(@"c:\configPath\sleet.json", @"singleSubFolder", @"c:\configPath\singleSubFolder\")]
+        [InlineData(@"c:\configPath\sleet.json", @"nestedSubFolder\a", @"c:\configPath\nestedSubFolder\a\")]
+        [InlineData(@"c:\configPath\sleet.json", @"c:\absolutePath", @"c:\absolutePath\")]
+        [InlineData(@"\\some-network-share\share\sleet.json", @"singleSubFolder", @"\\some-network-share\share\singleSubFolder\")]
+        [InlineData(@"\\some-network-share\share\sleet.json", @"nestedSubFolder\a", @"\\some-network-share\share\nestedSubFolder\a\")]
+        [InlineData(@"\\some-network-share\share\sleet.json", @".\", @"\\some-network-share\share\")]
+        [InlineData(@"file:///c:/configPath/sleet.json", @"", @"c:\configPath\")]
+        [InlineData(@"file:///c:/configPath/sleet.json", @"singleSubFolder", @"c:\configPath\singleSubFolder\")]
+        [InlineData(@"file:///c:/configPath/sleet.json", @"nestedSubFolder\a", @"c:\configPath\nestedSubFolder\a\")]
         public void Feed_LocalTypeSupportsRelativePath(string configPath, string outputPath, string expected)
         {
             using (var cache = new LocalCache())


### PR DESCRIPTION
- Corrects misnamed `sleet.json` in tests and error messages
- Makes relative paths work when `sleet.json` is unspecified or specified as file in current directory

Fixes #59 