### PR TITLE
Add performance summary

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,5 +1,12 @@
 # Release Notes
 
+## 2.3.73
+* Reduced default log output, http get/push calls will now only be shown on verbose mode.
+* Performance summary displays where time was spent during push operations.
+* Push batch support. Instead of pushing possibly hundreds of thousands of packages at once push will now load nupkgs in batches and process them to avoid running out of memory.
+* Files are now ordered during upload. Index files will be pushed last to help avoid conflicts on the client when the feed is still incomplete.
+* Increased the delay for obtaining a file lock on azure feeds. Cleaned up file lock logging.
+
 ## 2.3.36
 * Path property in sleet.json can now be a relative path for local feeds
 

--- a/build/config.props
+++ b/build/config.props
@@ -24,7 +24,7 @@
     <RepositoryUrl>https://github.com/emgarten/Sleet</RepositoryUrl>
     <PackageTags>nuget nugetserver nugetfeed</PackageTags>
     <Description>Sleet creates nuget v3.0.0 nupkg feeds.</Description>
-    <Copyright>Copyright © 2017 Justin Emgarten</Copyright>
+    <Copyright>Copyright © 2019 Justin Emgarten</Copyright>
     <PackageIconUrl>https://emgartenstatic.blob.core.windows.net/nupkgs/icons/sleet.png</PackageIconUrl>
   </PropertyGroup>
 

--- a/src/Sleet/DeleteAppCommand.cs
+++ b/src/Sleet/DeleteAppCommand.cs
@@ -50,7 +50,7 @@ namespace Sleet
                 Util.SetVerbosity(log, verbose.HasValue());
 
                 // Create a temporary folder for caching files during the operation.
-                using (var cache = new LocalCache())
+                using (var cache = new LocalCache(new PerfTracker()))
                 {
                     // Load settings and file system.
                     var settings = LocalSettings.Load(optionConfigFile.Value(), SettingsUtility.GetPropertyMappings(propertyOptions.Values));

--- a/src/Sleet/Program.cs
+++ b/src/Sleet/Program.cs
@@ -10,7 +10,7 @@ namespace Sleet
     {
         public static int Main(string[] args)
         {
-            var logLevel = LogLevel.Minimal;
+            var logLevel = Util.DefaultLogLevel;
 
             if (CmdUtils.IsDebugModeEnabled())
             {

--- a/src/Sleet/PushAppCommand.cs
+++ b/src/Sleet/PushAppCommand.cs
@@ -54,7 +54,7 @@ namespace Sleet
                 Util.SetVerbosity(log, verbose.HasValue());
 
                 // Create a temporary folder for caching files during the operation.
-                using (var cache = new LocalCache())
+                using (var cache = new LocalCache(new PerfTracker()))
                 {
                     // Load settings and file system.
                     var settings = LocalSettings.Load(optionConfigFile.Value(), SettingsUtility.GetPropertyMappings(propertyOptions.Values));

--- a/src/Sleet/Sleet.nuspec
+++ b/src/Sleet/Sleet.nuspec
@@ -9,7 +9,7 @@
     <licenseUrl>https://github.com/emgarten/Sleet/blob/master/LICENSE.md</licenseUrl>
     <projectUrl>https://github.com/emgarten/Sleet/</projectUrl>
     <description>Sleet is a static feed generator for NuGet package feeds.</description>
-    <copyright>Copyright © 2017 Justin Emgarten</copyright>
+    <copyright>Copyright © 2019 Justin Emgarten</copyright>
     <tags>nuget nugetserver nugetfeed</tags>
     <repository type="git" url="https://github.com/emgarten/Sleet" branch="$branch$" commit="$commit$" />
     <developmentDependency>true</developmentDependency>

--- a/src/Sleet/Util.cs
+++ b/src/Sleet/Util.cs
@@ -7,6 +7,8 @@ namespace Sleet
 {
     internal static class Util
     {
+        internal static LogLevel DefaultLogLevel = LogLevel.Information;
+
         internal static ISleetFileSystem CreateFileSystemOrThrow(LocalSettings settings, string sourceName, LocalCache cache)
         {
             var sourceNamePassed = !string.IsNullOrEmpty(sourceName);
@@ -83,7 +85,7 @@ namespace Sleet
                 }
                 else
                 {
-                    consoleLogger.VerbosityLevel = LogLevel.Information;
+                    consoleLogger.VerbosityLevel = DefaultLogLevel;
                     consoleLogger.CollapseMessages = true;
                 }
             }

--- a/src/SleetLib/Common/SleetFileComparer.cs
+++ b/src/SleetLib/Common/SleetFileComparer.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace Sleet
+{
+    /// <summary>
+    /// Order files in a way that helps avoid clients discovering packages from index files
+    /// before the package files have been uploaded.
+    ///
+    /// Order of upload:
+    /// 1) Nupkg/nuspec files, these are usually the largest and slowest files
+    /// 2) Misc files such as package details pages and catalog entry pages.
+    /// 3) index.json files
+    /// 4) Search page
+    /// 
+    /// </summary>
+    public class SleetFileComparer : IComparer<ISleetFile>
+    {
+        public int Compare(ISleetFile x, ISleetFile y)
+        {
+            if (x == null)
+            {
+                throw new ArgumentNullException(nameof(x));
+            }
+
+            if (y == null)
+            {
+                throw new ArgumentNullException(nameof(y));
+            }
+
+            var priX = GetPriority(x);
+            var priY = GetPriority(y);
+
+            if (priX < priY)
+            {
+                return -1;
+            }
+
+            if (priX > priY)
+            {
+                return 1;
+            }
+
+            // Fallback to string compare
+            return StringComparer.OrdinalIgnoreCase.Compare(x.EntityUri.AbsoluteUri, y.EntityUri.AbsoluteUri);
+        }
+
+        private static int GetPriority(ISleetFile file)
+        {
+            var fileName = file.EntityUri.AbsoluteUri.Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries).Last().ToLowerInvariant();
+
+            if (!string.IsNullOrEmpty(fileName))
+            {
+                if (fileName.IndexOf('.') > -1)
+                {
+                    var extension = Path.GetExtension(fileName).ToLowerInvariant();
+                    switch (extension)
+                    {
+                        case "nupkg":
+                            return 1;
+                        case "nuspec":
+                            return 2;
+                    }
+                }
+
+                switch (fileName)
+                {
+                    case "index.json":
+                        // Upload index.json files last after everything else is in place
+                        return 7;
+                    case "query":
+                        // Update search after index files
+                        return 8;
+                }
+            }
+
+            return 5;
+        }
+    }
+}

--- a/src/SleetLib/FileSystem/AmazonS3File.cs
+++ b/src/SleetLib/FileSystem/AmazonS3File.cs
@@ -24,7 +24,7 @@ namespace Sleet
             IAmazonS3 client,
             string bucketName,
             string key)
-            : base(fileSystem, rootPath, displayPath, localCacheFile)
+            : base(fileSystem, rootPath, displayPath, localCacheFile, fileSystem.LocalCache.PerfTracker)
         {
             this.client = client;
             this.bucketName = bucketName;
@@ -37,7 +37,7 @@ namespace Sleet
             if (!await FileExistsAsync(client, bucketName, key, token).ConfigureAwait(false))
                 return;
 
-            log.LogInformation($"GET {absoluteUri}");
+            log.LogVerbose($"GET {absoluteUri}");
 
             if (File.Exists(LocalCacheFile.FullName))
                 LocalCacheFile.Delete();
@@ -50,7 +50,7 @@ namespace Sleet
 
             if (contentEncoding?.Equals("gzip", StringComparison.OrdinalIgnoreCase) == true)
             {
-                log.LogInformation($"Decompressing {absoluteUri}");
+                log.LogVerbose($"Decompressing {absoluteUri}");
 
                 var gzipFile = LocalCacheFile.FullName + ".gz";
                 File.Move(LocalCacheFile.FullName, gzipFile);
@@ -71,18 +71,18 @@ namespace Sleet
             {
                 if (await FileExistsAsync(client, bucketName, key, token).ConfigureAwait(false))
                 {
-                    log.LogInformation($"Removing {absoluteUri}");
+                    log.LogVerbose($"Removing {absoluteUri}");
                     await RemoveFileAsync(client, bucketName, key, token).ConfigureAwait(false);
                 }
                 else
                 {
-                    log.LogInformation($"Skipping {absoluteUri}");
+                    log.LogVerbose($"Skipping {absoluteUri}");
                 }
 
                 return;
             }
 
-            log.LogInformation($"Pushing {absoluteUri}");
+            log.LogVerbose($"Pushing {absoluteUri}");
 
             using (var cache = LocalCacheFile.OpenRead())
             {
@@ -104,7 +104,7 @@ namespace Sleet
                     contentEncoding = "gzip";
 
                     // Compress content before uploading
-                    log.LogInformation($"Compressing {absoluteUri}");
+                    log.LogVerbose($"Compressing {absoluteUri}");
                     writeStream = await JsonUtility.GZipAndMinifyAsync(cache);
                 }
                 else if (key.EndsWith(".dll", StringComparison.OrdinalIgnoreCase)

--- a/src/SleetLib/FileSystem/AzureFile.cs
+++ b/src/SleetLib/FileSystem/AzureFile.cs
@@ -15,7 +15,7 @@ namespace Sleet
         private readonly CloudBlockBlob _blob;
 
         internal AzureFile(AzureFileSystem fileSystem, Uri rootPath, Uri displayPath, FileInfo localCacheFile, CloudBlockBlob blob)
-            : base(fileSystem, rootPath, displayPath, localCacheFile)
+            : base(fileSystem, rootPath, displayPath, localCacheFile, fileSystem.LocalCache.PerfTracker)
         {
             _blob = blob;
         }
@@ -24,7 +24,7 @@ namespace Sleet
         {
             if (await _blob.ExistsAsync())
             {
-                log.LogInformation($"GET {_blob.Uri.AbsoluteUri}");
+                log.LogVerbose($"GET {_blob.Uri.AbsoluteUri}");
 
                 if (File.Exists(LocalCacheFile.FullName))
                 {
@@ -39,7 +39,7 @@ namespace Sleet
                 // If the blob is compressed it needs to be decompressed locally before it can be used
                 if (_blob.Properties.ContentEncoding?.Equals("gzip", StringComparison.OrdinalIgnoreCase) == true)
                 {
-                    log.LogInformation($"Decompressing {_blob.Uri.AbsoluteUri}");
+                    log.LogVerbose($"Decompressing {_blob.Uri.AbsoluteUri}");
 
                     var gzipFile = LocalCacheFile.FullName + ".gz";
                     File.Move(LocalCacheFile.FullName, gzipFile);
@@ -58,7 +58,7 @@ namespace Sleet
         {
             if (File.Exists(LocalCacheFile.FullName))
             {
-                log.LogInformation($"Pushing {_blob.Uri.AbsoluteUri}");
+                log.LogVerbose($"Pushing {_blob.Uri.AbsoluteUri}");
 
                 using (var cache = LocalCacheFile.OpenRead())
                 {
@@ -80,7 +80,7 @@ namespace Sleet
                         _blob.Properties.ContentEncoding = "gzip";
 
                         // Compress content before uploading
-                        log.LogInformation($"Compressing {_blob.Uri.AbsoluteUri}");
+                        log.LogVerbose($"Compressing {_blob.Uri.AbsoluteUri}");
                         writeStream = await JsonUtility.GZipAndMinifyAsync(cache);
                     }
                     else if (_blob.Uri.AbsoluteUri.EndsWith(".dll", StringComparison.OrdinalIgnoreCase)
@@ -107,12 +107,12 @@ namespace Sleet
             }
             else if (await _blob.ExistsAsync())
             {
-                log.LogInformation($"Removing {_blob.Uri.AbsoluteUri}");
+                log.LogVerbose($"Removing {_blob.Uri.AbsoluteUri}");
                 await _blob.DeleteAsync();
             }
             else
             {
-                log.LogInformation($"Skipping {_blob.Uri.AbsoluteUri}");
+                log.LogVerbose($"Skipping {_blob.Uri.AbsoluteUri}");
             }
         }
 

--- a/src/SleetLib/FileSystem/LocalCache.cs
+++ b/src/SleetLib/FileSystem/LocalCache.cs
@@ -10,13 +10,29 @@ namespace Sleet
         {
         }
 
+        public LocalCache(IPerfTracker perfTracker)
+            : this(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString()), perfTracker)
+        {
+        }
+
         public LocalCache(string path)
+            : this(path, perfTracker: null)
+        {
+        }
+
+        public LocalCache(string path, IPerfTracker perfTracker)
         {
             Root = new DirectoryInfo(path);
             Root.Create();
+            PerfTracker = perfTracker ?? NullPerfTracker.Instance;
         }
 
         public DirectoryInfo Root { get; }
+
+        /// <summary>
+        /// Performance related tracking
+        /// </summary>
+        public IPerfTracker PerfTracker { get; }
 
         public FileInfo GetNewTempPath()
         {

--- a/src/SleetLib/FileSystem/PhysicalFile.cs
+++ b/src/SleetLib/FileSystem/PhysicalFile.cs
@@ -12,7 +12,7 @@ namespace Sleet
         private readonly FileInfo _sourceFile;
 
         internal PhysicalFile(PhysicalFileSystem fileSystem, Uri rootPath, Uri displayPath, FileInfo localCacheFile, FileInfo sourceFile)
-            : base(fileSystem, rootPath, displayPath, localCacheFile)
+            : base(fileSystem, rootPath, displayPath, localCacheFile, fileSystem.LocalCache.PerfTracker)
         {
             _sourceFile = sourceFile;
         }
@@ -21,7 +21,7 @@ namespace Sleet
         {
             if (File.Exists(_sourceFile.FullName))
             {
-                log.LogInformation($"GET {_sourceFile.FullName}");
+                log.LogVerbose($"GET {_sourceFile.FullName}");
                 _sourceFile.CopyTo(LocalCacheFile.FullName);
             }
 
@@ -32,7 +32,7 @@ namespace Sleet
         {
             if (File.Exists(LocalCacheFile.FullName))
             {
-                log.LogInformation($"Pushing {_sourceFile.FullName}");
+                log.LogVerbose($"Pushing {_sourceFile.FullName}");
 
                 _sourceFile.Directory.Create();
 
@@ -56,20 +56,20 @@ namespace Sleet
             }
             else if (File.Exists(_sourceFile.FullName))
             {
-                log.LogInformation($"Removing {_sourceFile.FullName}");
+                log.LogVerbose($"Removing {_sourceFile.FullName}");
                 _sourceFile.Delete();
 
                 if (!Directory.EnumerateFiles(_sourceFile.DirectoryName).Any()
                     && !Directory.EnumerateDirectories(_sourceFile.DirectoryName).Any())
                 {
                     // Remove the parent directory if it is now empty
-                    log.LogInformation($"Removing {_sourceFile.DirectoryName}");
+                    log.LogVerbose($"Removing {_sourceFile.DirectoryName}");
                     _sourceFile.Directory.Delete();
                 }
             }
             else
             {
-                log.LogInformation($"Skipping {_sourceFile.FullName}");
+                log.LogVerbose($"Skipping {_sourceFile.FullName}");
             }
 
             return Task.FromResult(true);

--- a/src/SleetLib/FileSystem/PhysicalFileSystemLock.cs
+++ b/src/SleetLib/FileSystem/PhysicalFileSystemLock.cs
@@ -37,11 +37,11 @@ namespace Sleet
         public Task<bool> GetLock(TimeSpan wait, CancellationToken token)
         {
             var result = false;
-
-            var timer = new Stopwatch();
-            timer.Start();
-
-            var lastNotify = TimeSpan.Zero;
+            var timer = Stopwatch.StartNew();
+            var lastNotify = Stopwatch.StartNew();
+            var notifyDelay = TimeSpan.FromMinutes(5);
+            var waitTime = TimeSpan.FromMilliseconds(200);
+            var firstLoop = true;
 
             do
             {
@@ -67,14 +67,14 @@ namespace Sleet
 
                 if (!result)
                 {
-                    var diff = timer.Elapsed.Subtract(lastNotify);
-
-                    if (diff.TotalSeconds > 60)
+                    if (lastNotify.Elapsed >= notifyDelay || firstLoop)
                     {
                         _log.LogMinimal($"Waiting to obtain an exclusive lock on the feed.");
+                        lastNotify.Restart();
+                        firstLoop = false;
                     }
 
-                    Thread.Sleep(100);
+                    Thread.Sleep(waitTime);
                 }
             }
             while (!result && timer.Elapsed < wait);

--- a/src/SleetLib/Logging/IPerfTracker.cs
+++ b/src/SleetLib/Logging/IPerfTracker.cs
@@ -1,0 +1,19 @@
+using System.Threading.Tasks;
+using NuGet.Common;
+
+namespace Sleet
+{
+    public interface IPerfTracker
+    {
+        /// <summary>
+        /// Add a perf entry
+        /// </summary>
+        /// <param name="entry"></param>
+        void Add(PerfEntryBase entry);
+
+        /// <summary>
+        /// Write out the perf summary to the logger.
+        /// </summary>
+        Task LogSummary(ILogger log);
+    }
+}

--- a/src/SleetLib/Logging/NullPerfTracker.cs
+++ b/src/SleetLib/Logging/NullPerfTracker.cs
@@ -1,0 +1,21 @@
+using System.Threading.Tasks;
+using NuGet.Common;
+
+namespace Sleet
+{
+    public class NullPerfTracker : IPerfTracker
+    {
+        public void Add(PerfEntryBase entry)
+        {
+            // Noop
+        }
+
+        public Task LogSummary(ILogger log)
+        {
+            // Noop
+            return Task.FromResult(true);
+        }
+
+        public static NullPerfTracker Instance = new NullPerfTracker();
+    }
+}

--- a/src/SleetLib/Logging/PerfEntryBase.cs
+++ b/src/SleetLib/Logging/PerfEntryBase.cs
@@ -1,0 +1,57 @@
+using System;
+
+namespace Sleet
+{
+    /// <summary>
+    /// Performance log message
+    /// </summary>
+    public abstract class PerfEntryBase : IComparable<PerfEntryBase>
+    {
+        /// <summary>
+        /// Time the event took.
+        /// </summary>
+        public TimeSpan ElapsedTime { get; }
+
+        /// <summary>
+        /// Cutoff time. Only show the event if the time was greater than this time.
+        /// </summary>
+        public TimeSpan MinTimeToShow { get; }
+
+        public PerfEntryBase(TimeSpan elapsedTime, TimeSpan minTimeToShow)
+        {
+            ElapsedTime = elapsedTime;
+            MinTimeToShow = minTimeToShow;
+        }
+
+        /// <summary>
+        /// Construct the message to display.
+        /// </summary>
+        public abstract string GetMessage(TimeSpan timeSpan);
+
+        /// <summary>
+        /// Key to merge on.
+        /// </summary>
+        public abstract string Key
+        {
+            get;
+        }
+
+        /// <summary>
+        /// True if the event took long enough that it should be displayed.
+        /// </summary>
+        public bool ShouldShow()
+        {
+            return ElapsedTime >= MinTimeToShow;
+        }
+
+        public override string ToString()
+        {
+            return GetMessage(ElapsedTime);
+        }
+
+        public int CompareTo(PerfEntryBase other)
+        {
+            return ElapsedTime.CompareTo(other.ElapsedTime);
+        }
+    }
+}

--- a/src/SleetLib/Logging/PerfEntryWrapper.cs
+++ b/src/SleetLib/Logging/PerfEntryWrapper.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Diagnostics;
+
+namespace Sleet
+{
+    public static class PerfEntryWrapper
+    {
+        public static PerfEntryWrapper<PerfFileEntry> CreateModifyTimer(ISleetFile file, SleetContext context)
+        {
+            return CreateModifyTimer(file, context.PerfTracker);
+        }
+
+        public static PerfEntryWrapper<PerfFileEntry> CreateModifyTimer(ISleetFile file, IPerfTracker tracker)
+        {
+            return CreateFileTimer(file, tracker, PerfFileEntry.FileOperation.Modify);
+        }
+
+        public static PerfEntryWrapper<PerfFileEntry> CreateFileTimer(ISleetFile file, IPerfTracker tracker, PerfFileEntry.FileOperation operation)
+        {
+            return new PerfEntryWrapper<PerfFileEntry>(tracker, (time) => new PerfFileEntry(time, file.EntityUri, operation));
+        }
+
+        public static PerfEntryWrapper<PerfSummaryEntry> CreateSummaryTimer(string message, IPerfTracker tracker)
+        {
+            return new PerfEntryWrapper<PerfSummaryEntry>(tracker, (time) => new PerfSummaryEntry(time, message));
+        }
+
+        public static PerfEntryWrapper<PerfSummaryEntry> CreateSummaryTimer(string message, IPerfTracker tracker, TimeSpan minTimeToShow)
+        {
+            return new PerfEntryWrapper<PerfSummaryEntry>(tracker, (time) => new PerfSummaryEntry(time, message, minTimeToShow));
+        }
+    }
+
+    /// <summary>
+    /// Time an action and log the result to the perf tracker.
+    /// </summary>
+    public class PerfEntryWrapper<T> : IDisposable where T : PerfEntryBase
+    {
+        private readonly IPerfTracker _tracker;
+        private readonly Func<TimeSpan, T> _getEntry;
+        private readonly Stopwatch _timer = Stopwatch.StartNew();
+
+        public PerfEntryWrapper(IPerfTracker tracker, Func<TimeSpan, T> getEntry)
+        {
+            _tracker = tracker ?? throw new ArgumentNullException(nameof(tracker));
+            _getEntry = getEntry ?? throw new ArgumentNullException(nameof(getEntry));
+        }
+
+        public void Dispose()
+        {
+            // Log the event
+            _timer.Stop();
+            _tracker.Add(_getEntry(_timer.Elapsed));
+        }
+    }
+}

--- a/src/SleetLib/Logging/PerfFileEntry.cs
+++ b/src/SleetLib/Logging/PerfFileEntry.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Sleet
+{
+    /// <summary>
+    /// Perf stats for a specific URI
+    /// </summary>
+    public class PerfFileEntry : PerfEntryBase
+    {
+        private static readonly TimeSpan DefaultMinTime = TimeSpan.Zero;
+
+        public Uri File { get; }
+
+        public FileOperation Operation { get; }
+
+        public override string Key => $"{File.AbsoluteUri}-{Operation}";
+
+        public PerfFileEntry(TimeSpan elapsedTime, Uri file, FileOperation operation)
+            : base(elapsedTime, DefaultMinTime)
+        {
+            File = file;
+            Operation = operation;
+        }
+
+        public PerfFileEntry(TimeSpan elapsedTime, Uri file, FileOperation operation, TimeSpan minTimeToShow)
+            : base(elapsedTime, minTimeToShow)
+        {
+            File = file;
+            Operation = operation;
+        }
+
+        public override string GetMessage(TimeSpan timeSpan)
+        {
+            return $"({Operation.ToString().ToUpperInvariant()}) {File.PathAndQuery} : {PrintUtility.GetTimeString(timeSpan)}";
+        }
+
+        public static PerfFileEntry Merge(List<PerfFileEntry> entries)
+        {
+            if (entries.Count == 1)
+            {
+                return entries[0];
+            }
+
+            var oldest = entries[0];
+            var totalTime = entries.Select(e => e.ElapsedTime).Aggregate(TimeSpan.Zero, (sum, e) => sum.Add(e));
+
+            return oldest.WithElapsedTime(totalTime);
+        }
+
+        public PerfFileEntry WithElapsedTime(TimeSpan elapsedTime)
+        {
+            return new PerfFileEntry(elapsedTime, File, Operation, MinTimeToShow);
+        }
+
+        public enum FileOperation
+        {
+            // Download time
+            Get = 0,
+
+            // Local processing time
+            Modify = 1,
+
+            // Upload time
+            Put = 2,
+
+            // Write to disk
+            LocalWrite = 3,
+        }
+    }
+}

--- a/src/SleetLib/Logging/PerfSummaryEntry.cs
+++ b/src/SleetLib/Logging/PerfSummaryEntry.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Sleet
+{
+    /// <summary>
+    /// A basic perf log message that displays the time for an event.
+    /// </summary>
+    public class PerfSummaryEntry : PerfEntryBase
+    {
+        public DateTimeOffset Created { get; }
+
+        public override string Key { get; }
+
+        public PerfSummaryEntry(TimeSpan elapsedTime, string summaryMessage)
+            : this(elapsedTime, summaryMessage, TimeSpan.Zero)
+        {
+        }
+
+        public PerfSummaryEntry(TimeSpan elapsedTime, string summaryMessage, TimeSpan minTimeToShow)
+         : this(elapsedTime, summaryMessage, minTimeToShow, DateTimeOffset.UtcNow)
+        {
+        }
+
+        public PerfSummaryEntry(TimeSpan elapsedTime, string summaryMessage, TimeSpan minTimeToShow, DateTimeOffset created)
+            : base(elapsedTime, minTimeToShow)
+        {
+            Key = summaryMessage;
+            Created = created;
+        }
+
+        public override string GetMessage(TimeSpan timeSpan)
+        {
+            return string.Format(Key, PrintUtility.GetTimeString(timeSpan));
+        }
+
+        public static PerfSummaryEntry Merge(List<PerfSummaryEntry> entries)
+        {
+            if (entries.Count == 1)
+            {
+                return entries[0];
+            }
+
+            var oldest = entries.OrderBy(e => e.Created).First();
+            var totalTime = entries.Select(e => e.ElapsedTime).Aggregate(TimeSpan.Zero, (sum, e) => sum.Add(e));
+
+            return oldest.WithElapsedTime(totalTime);
+        }
+
+        public PerfSummaryEntry WithElapsedTime(TimeSpan elapsedTime)
+        {
+            return new PerfSummaryEntry(elapsedTime, Key, MinTimeToShow, Created);
+        }
+    }
+}

--- a/src/SleetLib/Logging/PerfTracker.cs
+++ b/src/SleetLib/Logging/PerfTracker.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using NuGet.Common;
+
+namespace Sleet
+{
+    public class PerfTracker : IPerfTracker
+    {
+        private ConcurrentQueue<PerfEntryBase> _perfEntries = new ConcurrentQueue<PerfEntryBase>();
+
+        public void Add(PerfEntryBase entry)
+        {
+            _perfEntries.Enqueue(entry);
+        }
+
+        public async Task LogSummary(ILogger log)
+        {
+            await log.LogAsync(LogLevel.Information, Environment.NewLine + "====== Performance Summary ======");
+
+            var filesLookup = GetDictionary(_perfEntries.Select(e => e as PerfFileEntry).Where(e => e != null));
+            var files = new List<PerfFileEntry>(filesLookup.Count);
+            foreach (var set in filesLookup.Values)
+            {
+                files.Add(PerfFileEntry.Merge(set));
+            }
+
+            var summariesLookup = GetDictionary(_perfEntries.Select(e => e as PerfSummaryEntry).Where(e => e != null));
+            var summaries = new List<PerfSummaryEntry>(summariesLookup.Count);
+            foreach (var set in summariesLookup.Values)
+            {
+                summaries.Add(PerfSummaryEntry.Merge(set));
+            }
+
+            // Log top files
+            var topFiles = files.Where(e => e.ShouldShow()).OrderByDescending(e => e.ElapsedTime).Take(5).ToList();
+            if (topFiles.Count > 0)
+            {
+                foreach (var entry in topFiles)
+                {
+                    await log.LogAsync(LogLevel.Information, "  " + entry.ToString());
+                }
+
+                await log.LogAsync(LogLevel.Information, string.Empty);
+            }
+
+            // Log summaries
+            foreach (var entry in summaries.Where(e => e.ShouldShow()))
+            {
+                await log.LogAsync(LogLevel.Information, "  " + entry.ToString());
+            }
+        }
+
+        private static Dictionary<string, List<T>> GetDictionary<T>(IEnumerable<T> entries) where T : PerfEntryBase
+        {
+            var dict = new Dictionary<string, List<T>>(StringComparer.Ordinal);
+
+            foreach (var entry in entries)
+            {
+                var key = entry.Key;
+                List<T> list = null;
+                if (!dict.TryGetValue(key, out list))
+                {
+                    list = new List<T>() { entry };
+                    dict.Add(key, list);
+                }
+                else
+                {
+                    list.Add(entry);
+                }
+            }
+
+            return dict;
+        }
+    }
+}

--- a/src/SleetLib/Logging/SleetPerfGroup.cs
+++ b/src/SleetLib/Logging/SleetPerfGroup.cs
@@ -1,0 +1,14 @@
+namespace Sleet
+{
+    public enum SleetPerfGroup
+    {
+        Global,
+        Catalog,
+        Registration,
+        PackageIndex,
+        AutoComplete,
+        Search,
+        Symbols,
+        FlatContainer
+    }
+}

--- a/src/SleetLib/Services/PackageIndexFile.cs
+++ b/src/SleetLib/Services/PackageIndexFile.cs
@@ -256,13 +256,15 @@ namespace Sleet
         /// <summary>
         /// Create the file directly without loading the previous file.
         /// </summary>
-        public Task CreateAsync(PackageSets index)
+        public async Task CreateAsync(PackageSets index)
         {
-            // Create updated index
-            var json = CreateJson(index);
-            var isEmpty = (index.Packages.Index.Count < 1) && (index.Symbols.Index.Count < 1);
-
-            return SaveAsync(json, isEmpty);
+            using (var timer = PerfEntryWrapper.CreateModifyTimer(File, Context))
+            {
+                // Create updated index
+                var json = CreateJson(index);
+                var isEmpty = (index.Packages.Index.Count < 1) && (index.Symbols.Index.Count < 1);
+                await SaveAsync(json, isEmpty);
+            }
         }
 
         /// <summary>

--- a/src/SleetLib/SleetContext.cs
+++ b/src/SleetLib/SleetContext.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading;
 using NuGet.Common;
 
@@ -19,5 +19,7 @@ namespace Sleet
         public Guid CommitId { get; set; } = Guid.NewGuid();
 
         public DateTimeOffset OperationStart { get; set; } = DateTimeOffset.UtcNow;
+
+        public IPerfTracker PerfTracker { get; set; } = NullPerfTracker.Instance;
     }
 }

--- a/src/SleetLib/Utility/Extensions.cs
+++ b/src/SleetLib/Utility/Extensions.cs
@@ -165,5 +165,32 @@ namespace Sleet
             mem.Position = 0;
             return mem;
         }
+
+        /// <summary>
+        /// Partition a list into segements of a given number.
+        /// </summary>
+        internal static List<List<T>> Partition<T>(this IEnumerable<T> entries, int max)
+        {
+            var results = new List<List<T>>();
+            var set = new List<T>();
+
+            foreach (var entry in entries)
+            {
+                if (set.Count >= max)
+                {
+                    results.Add(set);
+                    set = new List<T>();
+                }
+
+                set.Add(entry);
+            }
+
+            if (set.Count > 0)
+            {
+                results.Add(set);
+            }
+
+            return results;
+        }
     }
 }

--- a/src/SleetLib/Utility/PrintUtility.cs
+++ b/src/SleetLib/Utility/PrintUtility.cs
@@ -1,0 +1,34 @@
+using System;
+
+namespace Sleet
+{
+    public static class PrintUtility
+    {
+        public static string GetBytesString(long bytes)
+        {
+            if (bytes > (1024 * 1024))
+            {
+                return $"{Math.Round((bytes / 1024f / 1024f), 2)} MB";
+            }
+
+            return $"{Math.Round((bytes / 1024f), 2)} KB";
+        }
+
+        public static string GetTimeString(TimeSpan span)
+        {
+            var result = string.Empty;
+
+            if (span.TotalMilliseconds <= 90000)
+            {
+                result = $"{Math.Ceiling(span.TotalMilliseconds)} ms";
+            }
+            else
+            {
+                // Use the time as is
+                result = span.ToString();
+            }
+
+            return result.Trim();
+        }
+    }
+}


### PR DESCRIPTION
* Reduced default log output, http get/push calls will now only be shown on verbose mode.
* Performance summary displays where time was spent during push operations.
* Push batch support. Instead of pushing possibly hundreds of thousands of packages at once push will now load nupkgs in batches and process them to avoid running out of memory.
* Files are now ordered during upload. Index files will be pushed last to help avoid conflicts on the client when the feed is still incomplete.
* Increased the delay for obtaining a file lock on azure feeds. Cleaned up file lock logging.