### PR TITLE
Reduce nupkg operations

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,5 +1,10 @@
 # Release Notes
 
+## 2.3.74
+* Skip package SHA512 hashing when the catalog is disabled. Package details blobs will no longer write this extra property.
+* ISleetFile.Link support
+* Nupkgs are no longer copied to the temp cache during push. This improves perf and saves disk space for large pushes.
+
 ## 2.3.73
 * Reduced default log output, http get/push calls will now only be shown on verbose mode.
 * Performance summary displays where time was spent during push operations.

--- a/src/SleetLib/FileSystem/AmazonS3File.cs
+++ b/src/SleetLib/FileSystem/AmazonS3File.cs
@@ -39,8 +39,7 @@ namespace Sleet
 
             log.LogVerbose($"GET {absoluteUri}");
 
-            if (File.Exists(LocalCacheFile.FullName))
-                LocalCacheFile.Delete();
+            DeleteInternal();
 
             string contentEncoding;
             using (var cache = File.OpenWrite(LocalCacheFile.FullName))
@@ -61,6 +60,8 @@ namespace Sleet
                 {
                     await zipStream.CopyToAsync(destination, DefaultCopyBufferSize, token).ConfigureAwait(false);
                 }
+
+                File.Delete(gzipFile);
             }
         }
 

--- a/src/SleetLib/FileSystem/AzureFile.cs
+++ b/src/SleetLib/FileSystem/AzureFile.cs
@@ -26,10 +26,7 @@ namespace Sleet
             {
                 log.LogVerbose($"GET {_blob.Uri.AbsoluteUri}");
 
-                if (File.Exists(LocalCacheFile.FullName))
-                {
-                    LocalCacheFile.Delete();
-                }
+                DeleteInternal();
 
                 using (var cache = File.OpenWrite(LocalCacheFile.FullName))
                 {
@@ -50,6 +47,8 @@ namespace Sleet
                     {
                         await zipStream.CopyToAsync(destination);
                     }
+
+                    File.Delete(gzipFile);
                 }
             }
         }

--- a/src/SleetLib/FileSystem/ISleetFile.cs
+++ b/src/SleetLib/FileSystem/ISleetFile.cs
@@ -42,6 +42,13 @@ namespace Sleet
 
         Task Write(JObject json, ILogger log, CancellationToken token);
 
+        /// <summary>
+        /// Link the file to an external file.
+        /// This is an alternative to Write which can be used for nupkgs
+        /// instead of copying them to the temp cache.
+        /// </summary>
+        void Link(string path, ILogger log, CancellationToken token);
+
         void Delete(ILogger log, CancellationToken token);
 
         /// <summary>

--- a/src/SleetLib/Services/VirtualCatalog.cs
+++ b/src/SleetLib/Services/VirtualCatalog.cs
@@ -32,13 +32,7 @@ namespace Sleet
         /// <summary>
         /// Catalog index.json file
         /// </summary>
-        public ISleetFile RootIndexFile
-        {
-            get
-            {
-                return _context.Source.Get(RootIndex);
-            }
-        }
+        public ISleetFile RootIndexFile => _context.Source.Get(RootIndex);
 
         /// <summary>
         /// Example: http://tempuri.org/virtualcatalog/

--- a/src/SleetLib/Utility/CatalogUtility.cs
+++ b/src/SleetLib/Utility/CatalogUtility.cs
@@ -138,17 +138,23 @@ namespace Sleet
                 json.Add("title", titleValue);
             }
 
-            using (var stream = File.OpenRead(packageInput.PackagePath))
+            // Avoid hashing the package for virtual catalog pages, it takes
+            // a long time for machines with slow disks. It also isn't used
+            // anywhere except in the real catalog.
+            if (writeFileList)
             {
-                using (var sha512 = SHA512.Create())
+                using (var stream = File.OpenRead(packageInput.PackagePath))
                 {
-                    var packageHash = Convert.ToBase64String(sha512.ComputeHash(stream));
+                    using (var sha512 = SHA512.Create())
+                    {
+                        var packageHash = Convert.ToBase64String(sha512.ComputeHash(stream));
 
-                    json.Add("packageHash", packageHash);
-                    json.Add("packageHashAlgorithm", "SHA512");
+                        json.Add("packageHash", packageHash);
+                        json.Add("packageHashAlgorithm", "SHA512");
+                    }
+
+                    json.Add("packageSize", stream.Length);
                 }
-
-                json.Add("packageSize", stream.Length);
             }
 
             json.Add("published", now.GetDateString());

--- a/src/SleetLib/Utility/Extensions.cs
+++ b/src/SleetLib/Utility/Extensions.cs
@@ -131,7 +131,7 @@ namespace Sleet
         /// <summary>
         /// Save an XML file to a stream.
         /// </summary>
-        public static MemoryStream AsMemoryStreamAsync(this XDocument doc)
+        public static MemoryStream AsMemoryStream(this XDocument doc)
         {
             var mem = new MemoryStream();
             doc.Save(mem);


### PR DESCRIPTION
* Skip package SHA512 hashing when the catalog is disabled. Package details blobs will no longer write this extra property.
* ISleetFile.Link support
* Nupkgs are no longer copied to the temp cache during push. This improves perf and saves disk space for large pushes.