### PR TITLE
Set proxy credentials using standard 'DefaultNetworkCredentials'

### DIFF
--- a/src/SleetLib/FileSystem/FileSystemFactory.cs
+++ b/src/SleetLib/FileSystem/FileSystemFactory.cs
@@ -136,7 +136,7 @@ namespace Sleet
                         var config = new AmazonS3Config()
                         {
                             RegionEndpoint = regionSystemName,
-                            ProxyCredentials = new NetworkCredential()
+                            ProxyCredentials = CredentialCache.DefaultNetworkCredentials
                         };
 
                         AmazonS3Client amazonS3Client = null;


### PR DESCRIPTION
Fixes #63 

This replaces the earlier attempt (#67) which only seemed to work occasionally. This is now using `CredentialCache.DefaultNetworkCredentials` which [is documented](https://docs.microsoft.com/en-us/dotnet/api/system.net.credentialcache.defaultnetworkcredentials?view=netcore-2.1) as the standard way to get the credentials of the current user. 

I have done more reading and experimenting and digging into the S3 SDK code and one thing to note is that the current proxy behaviour in the SDK is different between .net core and .net framework. I have verified that the solution works for .net core but could not get it to help with .net framework since the SDK doesn't look up the proxy settings for .net framework. It may be that they expect people to set it using app.config instead in which case this PR may still help.

