### PR TITLE
Add lock message

### DIFF
--- a/src/SleetLib/Commands/DeleteCommand.cs
+++ b/src/SleetLib/Commands/DeleteCommand.cs
@@ -20,7 +20,7 @@ namespace Sleet
             log.LogMinimal($"Reading feed {source.BaseURI.AbsoluteUri}");
 
             // Check if already initialized
-            using (var feedLock = await SourceUtility.VerifyInitAndLock(settings, source, log, token))
+            using (var feedLock = await SourceUtility.VerifyInitAndLock(settings, source, "Delete", log, token))
             {
                 // Validate source
                 await SourceUtility.ValidateFeedForClient(source, log, token);

--- a/src/SleetLib/Commands/DestroyCommand.cs
+++ b/src/SleetLib/Commands/DestroyCommand.cs
@@ -14,7 +14,7 @@ namespace Sleet
         {
             var token = CancellationToken.None;
 
-            using (var feedLock = await SourceUtility.VerifyInitAndLock(settings, source, log, token))
+            using (var feedLock = await SourceUtility.VerifyInitAndLock(settings, source, "Destroy", log, token))
             {
                 return await Destroy(settings, source, log, token);
             }

--- a/src/SleetLib/Commands/DownloadCommand.cs
+++ b/src/SleetLib/Commands/DownloadCommand.cs
@@ -36,7 +36,7 @@ namespace Sleet
                     if (!noLock)
                     {
                         // Lock
-                        feedLock = await SourceUtility.VerifyInitAndLock(settings, source, log, token);
+                        feedLock = await SourceUtility.VerifyInitAndLock(settings, source, "Download", log, token);
 
                         // Validate source
                         await UpgradeUtility.EnsureFeedVersionMatchesTool(source, log, token);

--- a/src/SleetLib/Commands/FeedSettingsCommand.cs
+++ b/src/SleetLib/Commands/FeedSettingsCommand.cs
@@ -29,7 +29,7 @@ namespace Sleet
             log.LogMinimal($"Reading feed {source.BaseURI.AbsoluteUri}");
 
             // Check if already initialized
-            using (var feedLock = await SourceUtility.VerifyInitAndLock(settings, source, log, token))
+            using (var feedLock = await SourceUtility.VerifyInitAndLock(settings, source, "Feed settings", log, token))
             {
                 // Validate source
                 var success = await UpgradeUtility.EnsureFeedVersionMatchesTool(source, log, token);

--- a/src/SleetLib/Commands/PushCommand.cs
+++ b/src/SleetLib/Commands/PushCommand.cs
@@ -43,8 +43,14 @@ namespace Sleet
 
                         if (feedLock == null)
                         {
+                            string lockMessage = null;
+                            if (packages.Count > 0)
+                            {
+                                lockMessage = $"Push of {packages[0].Identity.ToString()}";
+                            }
+
                             // Check if already initialized
-                            feedLock = await SourceUtility.VerifyInitAndLock(settings, source, log, token);
+                            feedLock = await SourceUtility.VerifyInitAndLock(settings, source, lockMessage, log, token);
 
                             // Validate source
                             await SourceUtility.ValidateFeedForClient(source, log, token);

--- a/src/SleetLib/Commands/RecreateCommand.cs
+++ b/src/SleetLib/Commands/RecreateCommand.cs
@@ -31,7 +31,7 @@ namespace Sleet
 
             log.LogMinimal($"Reading feed {source.BaseURI.AbsoluteUri}");
 
-            using (var feedLock = await SourceUtility.VerifyInitAndLock(settings, source, log, token))
+            using (var feedLock = await SourceUtility.VerifyInitAndLock(settings, source, "Recreate", log, token))
             {
                 if (!force)
                 {

--- a/src/SleetLib/Commands/StatsCommand.cs
+++ b/src/SleetLib/Commands/StatsCommand.cs
@@ -17,7 +17,7 @@ namespace Sleet
             var token = CancellationToken.None;
 
             // Check if already initialized
-            using (var feedLock = await SourceUtility.VerifyInitAndLock(settings, source, log, token))
+            using (var feedLock = await SourceUtility.VerifyInitAndLock(settings, source, "Stats", log, token))
             {
                 // Validate source
                 await UpgradeUtility.EnsureFeedVersionMatchesTool(source, log, token);

--- a/src/SleetLib/Commands/ValidateCommand.cs
+++ b/src/SleetLib/Commands/ValidateCommand.cs
@@ -18,7 +18,7 @@ namespace Sleet
             log.LogMinimal($"Reading feed {source.BaseURI.AbsoluteUri}");
 
             // Check if already initialized
-            using (var feedLock = await SourceUtility.VerifyInitAndLock(settings, source, log, token))
+            using (var feedLock = await SourceUtility.VerifyInitAndLock(settings, source, "Validate", log, token))
             {
                 // Validate source
                 await SourceUtility.ValidateFeedForClient(source, log, token);

--- a/src/SleetLib/FileSystem/AzureFileSystem.cs
+++ b/src/SleetLib/FileSystem/AzureFileSystem.cs
@@ -85,13 +85,10 @@ namespace Sleet
 
         public override ISleetFileSystemLock CreateLock(ILogger log)
         {
-            // Find display URI
-            var path = GetPath(AzureFileSystemLock.LockFile);
-            var relativePath = GetRelativePath(path);
-
-            // Create blob
-            var blob = _container.GetBlockBlobReference(relativePath);
-            return new AzureFileSystemLock(blob, log);
+            // Create blobs
+            var blob = _container.GetBlockBlobReference(GetRelativePath(GetPath(AzureFileSystemLock.LockFile)));
+            var messageBlob = _container.GetBlockBlobReference(GetRelativePath(GetPath(AzureFileSystemLock.LockFileMessage)));
+            return new AzureFileSystemLock(blob, messageBlob, log);
         }
 
         public override async Task<IReadOnlyList<ISleetFile>> GetFiles(ILogger log, CancellationToken token)

--- a/src/SleetLib/FileSystem/FileSystemLockBase.cs
+++ b/src/SleetLib/FileSystem/FileSystemLockBase.cs
@@ -1,0 +1,123 @@
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
+using NuGet.Common;
+
+namespace Sleet
+{
+    /// <summary>
+    /// Locks a feed/filesystem so that only a single client can update it.
+    /// </summary>
+    public abstract class FileSystemLockBase : ISleetFileSystemLock
+    {
+        private volatile bool _isLocked;
+
+        protected ILogger Log { get; set; }
+
+        public FileSystemLockBase(ILogger log)
+        {
+            Log = log ?? throw new ArgumentNullException(nameof(log));
+        }
+
+        /// <summary>
+        /// Wait between displaying wait messages.
+        /// </summary>
+        protected virtual TimeSpan DelayBewteenMessages => TimeSpan.FromMinutes(5);
+
+        /// <summary>
+        /// Time to wait before trying to get the lock again.
+        /// </summary>
+        protected virtual TimeSpan WaitBetweenAttempts => TimeSpan.FromSeconds(30);
+
+        public bool IsLocked
+        {
+            get => _isLocked;
+            protected set => _isLocked = value;
+        }
+
+        public async Task<bool> GetLock(TimeSpan wait, string lockMessage, CancellationToken token)
+        {
+            var result = false;
+            var timer = Stopwatch.StartNew();
+            var lastNotify = Stopwatch.StartNew();
+            var notifyDelay = DelayBewteenMessages;
+            var waitTime = WaitBetweenAttempts;
+            var firstLoop = true;
+
+            if (!_isLocked)
+            {
+                do
+                {
+                    var tryResult = await TryObtainLockAsync(lockMessage, token);
+                    result = tryResult.Item1;
+
+                    if (!result)
+                    {
+                        if (lastNotify.Elapsed >= notifyDelay || firstLoop)
+                        {
+                            var message = $"Waiting to obtain feed lock.";
+
+                            // Print out a message describing how currently has the feed locked.
+                            var messageJson = tryResult.Item2 ?? new JObject();
+                            if (messageJson.TryGetValue("date", out var dateValue) && messageJson.TryGetValue("message", out var messageValue))
+                            {
+                                message += $" Feed is locked by: {messageValue.ToObject<string>()} since: {dateValue.ToObject<string>()}";
+                            }
+                            else
+                            {
+                                message += " Client holding the lock did not provide a message, it may be using an older version of Sleet.";
+                            }
+
+                            if (!string.IsNullOrEmpty(ManualUnlockInstructions))
+                            {
+                                message += $" {ManualUnlockInstructions}";
+                            }
+
+                            Log.LogMinimal(message);
+                        }
+
+                        firstLoop = false;
+                        await Task.Delay(waitTime);
+                    }
+                }
+                while (!result && timer.Elapsed < wait);
+
+                if (!result)
+                {
+                    Log.LogError($"Unable to obtain a lock on the feed. Try again later. " + ManualUnlockInstructions);
+                }
+
+                _isLocked = result;
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Main lock/read message.
+        /// </summary>
+        protected abstract Task<Tuple<bool, JObject>> TryObtainLockAsync(string lockMessage, CancellationToken token);
+
+        /// <summary>
+        /// Additional instructions for manually unlocking the feed.
+        /// </summary>
+        protected virtual string ManualUnlockInstructions => string.Empty;
+
+        protected JObject GetMessageJson(string lockMessage)
+        {
+            return new JObject(
+                new JProperty("date", DateTime.UtcNow.ToString("o")),
+                new JProperty("message", lockMessage ?? string.Empty));
+        }
+
+        public abstract void Release();
+
+        public virtual void Dispose()
+        {
+            Release();
+        }
+
+    }
+}

--- a/src/SleetLib/FileSystem/ISleetFileSystemLock.cs
+++ b/src/SleetLib/FileSystem/ISleetFileSystemLock.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -9,7 +9,7 @@ namespace Sleet
         /// <summary>
         /// Enter the lock. Returns true if successful.
         /// </summary>
-        Task<bool> GetLock(TimeSpan wait, CancellationToken token);
+        Task<bool> GetLock(TimeSpan wait, string lockMessage, CancellationToken token);
 
         /// <summary>
         /// True if locked.

--- a/src/SleetLib/LocalSettings.cs
+++ b/src/SleetLib/LocalSettings.cs
@@ -23,6 +23,11 @@ namespace Sleet
         /// </summary>
         public TimeSpan FeedLockTimeout { get; set; } = TimeSpan.MaxValue;
 
+        /// <summary>
+        /// Message written to feedback. This will be shown to waiting clients.
+        /// </summary>
+        public string FeedLockMessage { get; set; }
+
         public static LocalSettings Load(JObject json)
         {
             return Load(json, null);

--- a/test/SleetLib.Tests/FileSystemLockTests.cs
+++ b/test/SleetLib.Tests/FileSystemLockTests.cs
@@ -1,8 +1,11 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using FluentAssertions;
+using Newtonsoft.Json.Linq;
 using NuGet.Test.Helpers;
 using Sleet;
 using Xunit;
@@ -11,6 +14,95 @@ namespace SleetLib.Tests
 {
     public class FileSystemLockTests
     {
+        [Fact]
+        public async Task FileSystemLock_VerifyMessageShownInLog()
+        {
+            using (var target = new TestFolder())
+            using (var cache = new LocalCache())
+            {
+                var log = new TestLogger();
+                var log2 = new TestLogger();
+                var fileSystem1 = new PhysicalFileSystem(cache, UriUtility.CreateUri(target.Root));
+                var fileSystem2 = new PhysicalFileSystem(cache, UriUtility.CreateUri(target.Root));
+                var settings = new LocalSettings();
+                var lockMessage = Guid.NewGuid().ToString();
+
+                await InitCommand.RunAsync(settings, fileSystem1, log);
+
+                var lockObj1 = await SourceUtility.VerifyInitAndLock(settings, fileSystem1, lockMessage, log, CancellationToken.None);
+                lockObj1.IsLocked.Should().BeTrue();
+
+                var lockObj2Task = Task.Run(async () => await SourceUtility.VerifyInitAndLock(settings, fileSystem2, lockMessage, log2, CancellationToken.None));
+
+                while (!log2.GetMessages().Contains($"Feed is locked by: {lockMessage}"))
+                {
+                    await Task.Delay(10);
+                }
+
+                lockObj1.Release();
+                var lockObj2 = await lockObj2Task;
+
+                while (!lockObj2.IsLocked)
+                {
+                    await Task.Delay(10);
+                }
+
+                lockObj1.IsLocked.Should().BeFalse();
+                lockObj2.IsLocked.Should().BeTrue();
+            }
+        }
+
+        [Fact]
+        public async Task FileSystemLock_VerifyMessage()
+        {
+            using (var target = new TestFolder())
+            using (var cache = new LocalCache())
+            {
+                var log = new TestLogger();
+                var fileSystem = new PhysicalFileSystem(cache, UriUtility.CreateUri(target.Root));
+                var settings = new LocalSettings();
+                var lockMessage = Guid.NewGuid().ToString();
+
+                await InitCommand.RunAsync(settings, fileSystem, log);
+
+                var lockObj = await SourceUtility.VerifyInitAndLock(settings, fileSystem, lockMessage, log, CancellationToken.None);
+                lockObj.IsLocked.Should().BeTrue();
+
+                var path = Path.Combine(target.Root, ".lock");
+                var json = JObject.Parse(File.ReadAllText(path));
+
+                json["message"].ToString().Should().Be(lockMessage);
+                json["date"].ToString().Should().NotBeNullOrEmpty();
+                json["pid"].ToString().Should().NotBeNullOrEmpty();
+            }
+        }
+
+        [Fact]
+        public async Task FileSystemLock_VerifyMessageFromSettings()
+        {
+            using (var target = new TestFolder())
+            using (var cache = new LocalCache())
+            {
+                var log = new TestLogger();
+                var fileSystem = new PhysicalFileSystem(cache, UriUtility.CreateUri(target.Root));
+                var settings = new LocalSettings();
+                settings.FeedLockMessage = "FROMSETTINGS!!";
+                var lockMessage = Guid.NewGuid().ToString();
+
+                await InitCommand.RunAsync(settings, fileSystem, log);
+
+                var lockObj = await SourceUtility.VerifyInitAndLock(settings, fileSystem, lockMessage, log, CancellationToken.None);
+                lockObj.IsLocked.Should().BeTrue();
+
+                var path = Path.Combine(target.Root, ".lock");
+                var json = JObject.Parse(File.ReadAllText(path));
+
+                json["message"].ToString().Should().Be("FROMSETTINGS!!");
+                json["date"].ToString().Should().NotBeNullOrEmpty();
+                json["pid"].ToString().Should().NotBeNullOrEmpty();
+            }
+        }
+
         [Fact]
         public async Task FileSystemLock_SameFileSystemAsync()
         {
@@ -26,9 +118,9 @@ namespace SleetLib.Tests
                 var lock3 = fileSystem.CreateLock(log);
 
                 // Act
-                var lock1Result = await lock1.GetLock(TimeSpan.FromSeconds(1), CancellationToken.None);
-                var lock2Result = await lock2.GetLock(TimeSpan.FromSeconds(1), CancellationToken.None);
-                var lock3Result = await lock3.GetLock(TimeSpan.FromSeconds(1), CancellationToken.None);
+                var lock1Result = await lock1.GetLock(TimeSpan.FromSeconds(1), string.Empty, CancellationToken.None);
+                var lock2Result = await lock2.GetLock(TimeSpan.FromSeconds(1), string.Empty, CancellationToken.None);
+                var lock3Result = await lock3.GetLock(TimeSpan.FromSeconds(1), string.Empty, CancellationToken.None);
 
                 // Assert
                 Assert.True(lock1Result);
@@ -38,8 +130,8 @@ namespace SleetLib.Tests
                 // Act
                 lock1.Release();
 
-                lock2Result = await lock2.GetLock(TimeSpan.FromSeconds(1), CancellationToken.None);
-                lock3Result = await lock3.GetLock(TimeSpan.FromSeconds(1), CancellationToken.None);
+                lock2Result = await lock2.GetLock(TimeSpan.FromSeconds(1), string.Empty, CancellationToken.None);
+                lock3Result = await lock3.GetLock(TimeSpan.FromSeconds(1), string.Empty, CancellationToken.None);
 
                 // Assert
                 Assert.True(lock2Result);
@@ -63,8 +155,8 @@ namespace SleetLib.Tests
                 var lock2 = fileSystem2.CreateLock(log);
 
                 // Act 1
-                var lock1Result = await lock1.GetLock(TimeSpan.FromSeconds(1), CancellationToken.None);
-                var lock2Result = await lock2.GetLock(TimeSpan.FromSeconds(1), CancellationToken.None);
+                var lock1Result = await lock1.GetLock(TimeSpan.FromSeconds(1), string.Empty, CancellationToken.None);
+                var lock2Result = await lock2.GetLock(TimeSpan.FromSeconds(1), string.Empty, CancellationToken.None);
 
                 // Assert 1
                 Assert.True(lock1Result);
@@ -73,7 +165,7 @@ namespace SleetLib.Tests
                 // Act 2
                 lock1.Release();
 
-                lock2Result = await lock2.GetLock(TimeSpan.FromSeconds(1), CancellationToken.None);
+                lock2Result = await lock2.GetLock(TimeSpan.FromSeconds(1), string.Empty, CancellationToken.None);
 
                 // Assert 2
                 Assert.True(lock2Result);
@@ -112,7 +204,7 @@ namespace SleetLib.Tests
 
                 var lockData = fileSystem.CreateLock(log);
 
-                var result = await lockData.GetLock(TimeSpan.FromMinutes(1), CancellationToken.None);
+                var result = await lockData.GetLock(TimeSpan.FromMinutes(1), string.Empty, CancellationToken.None);
 
                 try
                 {


### PR DESCRIPTION
Store details on the action being performed and when the lock was first obtained. Clients waiting for the lock can read this info to provide a helpful message to users waiting.