### PR TITLE
Add file system reset and cache invalidation

### DIFF
--- a/src/SleetLib/FileSystem/FileSystemBase.cs
+++ b/src/SleetLib/FileSystem/FileSystemBase.cs
@@ -214,5 +214,20 @@ namespace Sleet
 
             return pair;
         }
+
+        /// <summary>
+        /// Clear all tracked files
+        /// </summary>
+        public void Reset()
+        {
+            // Mark all files as invalid so that any external users will fail when trying to use them.
+            foreach (var file in Files.Values)
+            {
+                file.Invalidate();
+            }
+
+            // Clear all tracked filed
+            Files.Clear();
+        }
     }
 }

--- a/src/SleetLib/FileSystem/ISleetFile.cs
+++ b/src/SleetLib/FileSystem/ISleetFile.cs
@@ -69,5 +69,10 @@ namespace Sleet
         /// Fetch the file and then check if it exists.
         /// </summary>
         Task<bool> ExistsWithFetch(ILogger log, CancellationToken token);
+
+        /// <summary>
+        /// Invalidate a file that is no longer part of the file system. This file will throw an error when used.
+        /// </summary>
+        void Invalidate();
     }
 }

--- a/src/SleetLib/FileSystem/ISleetFileSystem.cs
+++ b/src/SleetLib/FileSystem/ISleetFileSystem.cs
@@ -48,5 +48,10 @@ namespace Sleet
         /// Optional sub path for the feed.
         /// </summary>
         string FeedSubPath { get;  }
+
+        /// <summary>
+        /// Reset the file system and clear all tracked and cached files.
+        /// </summary>
+        void Reset();
     }
 }

--- a/src/SleetLib/Utility/SourceUtility.cs
+++ b/src/SleetLib/Utility/SourceUtility.cs
@@ -49,6 +49,9 @@ namespace Sleet
                 timer.Stop();
                 fileSystem.LocalCache.PerfTracker.Add(new PerfSummaryEntry(timer.Elapsed, "Obtained feed lock in {0}", TimeSpan.FromSeconds(30)));
 
+                // Reset the file system to avoid using files retrieved before the lock, this would be unsafe
+                fileSystem.Reset();
+
                 var indexPath = fileSystem.Get("index.json");
 
                 if (!await indexPath.ExistsWithFetch(log, token))

--- a/test/Sleet.Integration.Tests/NuGetReaderTests.cs
+++ b/test/Sleet.Integration.Tests/NuGetReaderTests.cs
@@ -286,6 +286,7 @@ namespace Sleet.Integration.Test
                 var settings = LocalSettings.Load(sleetConfigPath);
                 var fileSystem = FileSystemFactory.CreateFileSystem(settings, cache, "local");
                 var success = await InitCommand.RunAsync(settings, fileSystem, log);
+                fileSystem.Reset();
 
                 // Act
                 // Run sleet

--- a/test/SleetLib.Tests/AddRemoveTests.cs
+++ b/test/SleetLib.Tests/AddRemoveTests.cs
@@ -54,12 +54,6 @@ namespace SleetLib.Tests
                     }
                 }
 
-                var catalog = new Catalog(context);
-                var registration = new Registrations(context);
-                var packageIndex = new PackageIndex(context);
-                var search = new Search(context);
-                var autoComplete = new AutoComplete(context);
-
                 await InitCommand.InitAsync(context);
                 await PushCommand.RunAsync(context.LocalSettings, context.Source, new List<string>() { packagesFolder.Root }, false, false, context.Log);
 
@@ -70,6 +64,12 @@ namespace SleetLib.Tests
                 var validateOutput = await ValidateCommand.RunAsync(context.LocalSettings, context.Source, context.Log);
 
                 // read output
+                var catalog = new Catalog(context);
+                var registration = new Registrations(context);
+                var packageIndex = new PackageIndex(context);
+                var search = new Search(context);
+                var autoComplete = new AutoComplete(context);
+
                 var catalogEntries = await catalog.GetIndexEntriesAsync();
                 var catalogExistingEntries = await catalog.GetExistingPackagesIndexAsync();
                 var catalogPackages = await catalog.GetPackagesAsync();
@@ -134,12 +134,6 @@ namespace SleetLib.Tests
                     }
                 }
 
-                var catalog = new Catalog(context);
-                var registration = new Registrations(context);
-                var packageIndex = new PackageIndex(context);
-                var search = new Search(context);
-                var autoComplete = new AutoComplete(context);
-
                 // Act
                 // run commands
                 await InitCommand.InitAsync(context);
@@ -147,6 +141,11 @@ namespace SleetLib.Tests
                 var validateOutput = await ValidateCommand.RunAsync(context.LocalSettings, context.Source, context.Log);
 
                 // read outputs
+                var catalog = new Catalog(context);
+                var registration = new Registrations(context);
+                var packageIndex = new PackageIndex(context);
+                var search = new Search(context);
+                var autoComplete = new AutoComplete(context);
                 var catalogEntries = await catalog.GetIndexEntriesAsync();
                 var catalogExistingEntries = await catalog.GetExistingPackagesIndexAsync();
                 var catalogPackages = await catalog.GetPackagesAsync();
@@ -209,12 +208,6 @@ namespace SleetLib.Tests
                 {
                     var input = PackageInput.Create(zipFile.FullName);
 
-                    var catalog = new Catalog(context);
-                    var registration = new Registrations(context);
-                    var packageIndex = new PackageIndex(context);
-                    var search = new Search(context);
-                    var autoComplete = new AutoComplete(context);
-
                     // Act
                     // run commands
                     await InitCommand.InitAsync(context);
@@ -222,6 +215,12 @@ namespace SleetLib.Tests
                     var validateOutput = await ValidateCommand.RunAsync(context.LocalSettings, context.Source, context.Log);
 
                     // read outputs
+                    var catalog = new Catalog(context);
+                    var registration = new Registrations(context);
+                    var packageIndex = new PackageIndex(context);
+                    var search = new Search(context);
+                    var autoComplete = new AutoComplete(context);
+
                     var catalogEntries = await catalog.GetIndexEntriesAsync();
                     var catalogExistingEntries = await catalog.GetExistingPackagesIndexAsync();
                     var catalogLatest = await catalog.GetLatestEntryAsync(input.Identity);
@@ -279,12 +278,6 @@ namespace SleetLib.Tests
                 {
                     var input = PackageInput.Create(zipFile.FullName);
 
-                    var catalog = new Catalog(context);
-                    var registration = new Registrations(context);
-                    var packageIndex = new PackageIndex(context);
-                    var search = new Search(context);
-                    var autoComplete = new AutoComplete(context);
-
                     // Act
                     // run commands
                     await InitCommand.InitAsync(context);
@@ -293,6 +286,12 @@ namespace SleetLib.Tests
                     var validateOutput = await ValidateCommand.RunAsync(context.LocalSettings, context.Source, context.Log);
 
                     // read outputs
+                    var catalog = new Catalog(context);
+                    var registration = new Registrations(context);
+                    var packageIndex = new PackageIndex(context);
+                    var search = new Search(context);
+                    var autoComplete = new AutoComplete(context);
+
                     var catalogEntries = await catalog.GetIndexEntriesAsync();
                     var catalogExistingEntries = await catalog.GetExistingPackagesIndexAsync();
                     var catalogLatest = await catalog.GetLatestEntryAsync(input.Identity);
@@ -353,7 +352,6 @@ namespace SleetLib.Tests
                 var zipFile3 = testPackage3.Save(packagesFolder.Root);
 
                 var toDelete = new List<PackageIdentity>() { new PackageIdentity("packageA", NuGetVersion.Parse("1.0.0")), new PackageIdentity("packageB", NuGetVersion.Parse("2.0.0")) };
-                var packageIndex = new PackageIndex(context);
 
                 // Act
                 // run commands
@@ -363,6 +361,7 @@ namespace SleetLib.Tests
                 var validateOutput = await ValidateCommand.RunAsync(context.LocalSettings, context.Source, context.Log);
 
                 // read outputs
+                var packageIndex = new PackageIndex(context);
                 var indexPackages = await packageIndex.GetPackagesAsync();
 
                 // Assert
@@ -404,12 +403,6 @@ namespace SleetLib.Tests
                 {
                     var input = PackageInput.Create(zipFile.FullName);
 
-                    var catalog = new Catalog(context);
-                    var registration = new Registrations(context);
-                    var packageIndex = new PackageIndex(context);
-                    var search = new Search(context);
-                    var autoComplete = new AutoComplete(context);
-
                     // Act
                     // run commands
                     await InitCommand.InitAsync(context);
@@ -417,6 +410,12 @@ namespace SleetLib.Tests
                     var validateOutput = await ValidateCommand.RunAsync(context.LocalSettings, context.Source, context.Log);
 
                     // read outputs
+                    var catalog = new Catalog(context);
+                    var registration = new Registrations(context);
+                    var packageIndex = new PackageIndex(context);
+                    var search = new Search(context);
+                    var autoComplete = new AutoComplete(context);
+
                     var catalogEntries = await catalog.GetIndexEntriesAsync();
                     var catalogExistingEntries = await catalog.GetExistingPackagesIndexAsync();
                     var catalogLatest = await catalog.GetLatestEntryAsync(input.Identity);
@@ -476,12 +475,6 @@ namespace SleetLib.Tests
                 {
                     var input = PackageInput.Create(zipFile.FullName);
 
-                    var catalog = new Catalog(context);
-                    var registration = new Registrations(context);
-                    var packageIndex = new PackageIndex(context);
-                    var search = new Search(context);
-                    var autoComplete = new AutoComplete(context);
-
                     // Act
                     // run commands
                     await InitCommand.InitAsync(context);
@@ -489,6 +482,12 @@ namespace SleetLib.Tests
                     var validateOutput = await ValidateCommand.RunAsync(context.LocalSettings, context.Source, context.Log);
 
                     // read outputs
+                    var catalog = new Catalog(context);
+                    var registration = new Registrations(context);
+                    var packageIndex = new PackageIndex(context);
+                    var search = new Search(context);
+                    var autoComplete = new AutoComplete(context);
+
                     var catalogEntries = await catalog.GetIndexEntriesAsync();
                     var catalogExistingEntries = await catalog.GetExistingPackagesIndexAsync();
                     var catalogLatest = await catalog.GetLatestEntryAsync(input.Identity);
@@ -550,12 +549,6 @@ namespace SleetLib.Tests
                 var zipFile2 = testPackage2.Save(packagesFolder.Root);
                 var zipFile3 = testPackage3.Save(packagesFolder.Root);
 
-                var catalog = new Catalog(context);
-                var registration = new Registrations(context);
-                var packageIndex = new PackageIndex(context);
-                var search = new Search(context);
-                var autoComplete = new AutoComplete(context);
-
                 // Act
                 // run commands
                 await InitCommand.InitAsync(context);
@@ -568,6 +561,12 @@ namespace SleetLib.Tests
                 var validateOutput = await ValidateCommand.RunAsync(context.LocalSettings, context.Source, context.Log);
 
                 // read outputs
+                var catalog = new Catalog(context);
+                var registration = new Registrations(context);
+                var packageIndex = new PackageIndex(context);
+                var search = new Search(context);
+                var autoComplete = new AutoComplete(context);
+
                 var catalogEntries = await catalog.GetIndexEntriesAsync();
                 var catalogExistingEntries = await catalog.GetExistingPackagesIndexAsync();
 
@@ -625,12 +624,6 @@ namespace SleetLib.Tests
                 var zipFile2 = testPackage2.Save(packagesFolder.Root);
                 var zipFile3 = testPackage3.Save(packagesFolder.Root);
 
-                var catalog = new Catalog(context);
-                var registration = new Registrations(context);
-                var packageIndex = new PackageIndex(context);
-                var search = new Search(context);
-                var autoComplete = new AutoComplete(context);
-
                 // Act
                 // run commands
                 await InitCommand.InitAsync(context);
@@ -644,6 +637,12 @@ namespace SleetLib.Tests
                 var validateOutput = await ValidateCommand.RunAsync(context.LocalSettings, context.Source, context.Log);
 
                 // read outputs
+                var catalog = new Catalog(context);
+                var registration = new Registrations(context);
+                var packageIndex = new PackageIndex(context);
+                var search = new Search(context);
+                var autoComplete = new AutoComplete(context);
+
                 var catalogEntries = await catalog.GetIndexEntriesAsync();
                 var catalogExistingEntries = await catalog.GetExistingPackagesIndexAsync();
 
@@ -698,12 +697,6 @@ namespace SleetLib.Tests
                     var input = PackageInput.Create(zipFile1.FullName);
                     var input2 = PackageInput.Create(zipFile2.FullName);
 
-                    var catalog = new Catalog(context);
-                    var registration = new Registrations(context);
-                    var packageIndex = new PackageIndex(context);
-                    var search = new Search(context);
-                    var autoComplete = new AutoComplete(context);
-
                     // Act
                     // run commands
                     await InitCommand.InitAsync(context);
@@ -712,6 +705,12 @@ namespace SleetLib.Tests
                     var validateOutput = await ValidateCommand.RunAsync(context.LocalSettings, context.Source, context.Log);
 
                     // read outputs
+                    var catalog = new Catalog(context);
+                    var registration = new Registrations(context);
+                    var packageIndex = new PackageIndex(context);
+                    var search = new Search(context);
+                    var autoComplete = new AutoComplete(context);
+
                     var catalogEntries = await catalog.GetIndexEntriesAsync();
                     var catalogExistingEntries = await catalog.GetExistingPackagesIndexAsync();
 
@@ -767,12 +766,6 @@ namespace SleetLib.Tests
                     var input1 = PackageInput.Create(zipFile1.FullName);
                     var input2 = PackageInput.Create(zipFile2.FullName);
 
-                    var catalog = new Catalog(context);
-                    var registration = new Registrations(context);
-                    var packageIndex = new PackageIndex(context);
-                    var search = new Search(context);
-                    var autoComplete = new AutoComplete(context);
-
                     // Act
                     // run commands
                     await InitCommand.InitAsync(context);
@@ -781,6 +774,12 @@ namespace SleetLib.Tests
                     var validateOutput = await ValidateCommand.RunAsync(context.LocalSettings, context.Source, context.Log);
 
                     // read outputs
+                    var catalog = new Catalog(context);
+                    var registration = new Registrations(context);
+                    var packageIndex = new PackageIndex(context);
+                    var search = new Search(context);
+                    var autoComplete = new AutoComplete(context);
+
                     var catalogEntries = await catalog.GetIndexEntriesAsync();
                     var catalogExistingEntries = await catalog.GetExistingPackagesIndexAsync();
 
@@ -839,12 +838,6 @@ namespace SleetLib.Tests
                     }
                 }
 
-                var catalog = new Catalog(context);
-                var registration = new Registrations(context);
-                var packageIndex = new PackageIndex(context);
-                var search = new Search(context);
-                var autoComplete = new AutoComplete(context);
-
                 // Act
                 // run commands
                 await InitCommand.InitAsync(context);
@@ -852,6 +845,12 @@ namespace SleetLib.Tests
                 var validateOutput = await ValidateCommand.RunAsync(context.LocalSettings, context.Source, context.Log);
 
                 // read outputs
+                var catalog = new Catalog(context);
+                var registration = new Registrations(context);
+                var packageIndex = new PackageIndex(context);
+                var search = new Search(context);
+                var autoComplete = new AutoComplete(context);
+
                 var catalogEntries = await catalog.GetIndexEntriesAsync();
                 var catalogExistingEntries = await catalog.GetExistingPackagesIndexAsync();
                 var catalogPackages = await catalog.GetPackagesAsync();

--- a/test/SleetLib.Tests/FeedTests.cs
+++ b/test/SleetLib.Tests/FeedTests.cs
@@ -5,10 +5,7 @@ using System.IO.Compression;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
-using NuGet.Packaging;
-using NuGet.Packaging.Core;
 using NuGet.Test.Helpers;
-using NuGet.Versioning;
 using Sleet;
 using Sleet.Test.Common;
 using Xunit;
@@ -64,12 +61,6 @@ namespace SleetLib.Tests
                 {
                     var input = PackageInput.Create(zipFile.FullName);
 
-                    var catalog = new Catalog(context);
-                    var registration = new Registrations(context);
-                    var packageIndex = new PackageIndex(context);
-                    var search = new Search(context);
-                    var autoComplete = new AutoComplete(context);
-
                     // Act
                     // run commands
                     await InitCommand.InitAsync(context);
@@ -77,6 +68,12 @@ namespace SleetLib.Tests
                     var validateOutput = await ValidateCommand.RunAsync(context.LocalSettings, context.Source, context.Log);
 
                     // read outputs
+                    var catalog = new Catalog(context);
+                    var registration = new Registrations(context);
+                    var packageIndex = new PackageIndex(context);
+                    var search = new Search(context);
+                    var autoComplete = new AutoComplete(context);
+
                     var catalogEntries = await catalog.GetIndexEntriesAsync();
                     var catalogExistingEntries = await catalog.GetExistingPackagesIndexAsync();
                     var catalogLatest = await catalog.GetLatestEntryAsync(input.Identity);

--- a/test/SleetLib.Tests/FileSystemTests.cs
+++ b/test/SleetLib.Tests/FileSystemTests.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Newtonsoft.Json.Linq;
+using NuGet.Test.Helpers;
+using Sleet;
+using Xunit;
+
+namespace SleetLib.Tests
+{
+    public class FileSystemTests
+    {
+        [Fact]
+        public async Task FileSystem_VerifyFileSystemResetOnLock()
+        {
+            using (var target = new TestFolder())
+            using (var cache = new LocalCache())
+            {
+                var log = new TestLogger();
+                var fileSystem1 = new PhysicalFileSystem(cache, UriUtility.CreateUri(target.Root));
+                var settings = new LocalSettings();
+                var lockMessage = Guid.NewGuid().ToString();
+
+                await InitCommand.RunAsync(settings, fileSystem1, log);
+
+                // Verify that files work normally
+                var testFile = fileSystem1.Get("test.json");
+                await testFile.GetJsonOrNull(log, CancellationToken.None);
+
+                var testFile2 = fileSystem1.Get("test2.json");
+                fileSystem1.Files.Count.Should().BeGreaterThan(1);
+
+                // Lock the feed to reset it
+                var lockObj1 = await SourceUtility.VerifyInitAndLock(settings, fileSystem1, lockMessage, log, CancellationToken.None);
+                lockObj1.IsLocked.Should().BeTrue();
+
+                // 1 file should be found since it loads the index
+                fileSystem1.Files.Count.Should().Be(1);
+                InvalidOperationException failureEx = null;
+
+                try
+                {
+                    // Verify the old file no longer works
+                    await testFile.GetJsonOrNull(log, CancellationToken.None);
+                    await testFile2.GetJsonOrNull(log, CancellationToken.None);
+                }
+                catch (InvalidOperationException ex)
+                {
+                    failureEx = ex;
+                }
+
+                failureEx.Should().NotBeNull();
+            }
+        }
+    }
+}

--- a/test/SleetLib.Tests/PushCommandTests.cs
+++ b/test/SleetLib.Tests/PushCommandTests.cs
@@ -65,12 +65,6 @@ namespace SleetLib.Tests
                 {
                     var input = PackageInput.Create(zipFile.FullName);
 
-                    var catalog = new Catalog(context);
-                    var registration = new Registrations(context);
-                    var packageIndex = new PackageIndex(context);
-                    var search = new Search(context);
-                    var autoComplete = new AutoComplete(context);
-
                     // Act
                     // run commands
                     await InitCommand.InitAsync(context);
@@ -78,6 +72,12 @@ namespace SleetLib.Tests
                     var validateOutput = await ValidateCommand.RunAsync(context.LocalSettings, context.Source, context.Log);
 
                     // read outputs
+                    var catalog = new Catalog(context);
+                    var registration = new Registrations(context);
+                    var packageIndex = new PackageIndex(context);
+                    var search = new Search(context);
+                    var autoComplete = new AutoComplete(context);
+
                     var catalogEntries = await catalog.GetIndexEntriesAsync();
                     var indexPackages = await packageIndex.GetPackagesAsync();
 

--- a/test/SleetLib.Tests/SymbolsTests.cs
+++ b/test/SleetLib.Tests/SymbolsTests.cs
@@ -382,8 +382,6 @@ namespace SleetLib.Tests
             {
                 var context = testContext.SleetContext;
                 context.SourceSettings.SymbolsEnabled = true;
-                var symbols = new Symbols(context);
-                var packageIndex = new PackageIndex(context);
 
                 // Create package
                 var pkgA = new TestNupkg("a", "1.0.0");
@@ -421,6 +419,9 @@ namespace SleetLib.Tests
                 var symbolsIndex = new HashSet<PackageIdentity>();
                 var packageIndexPkgs = new HashSet<PackageIdentity>();
 
+                var symbols = new Symbols(context);
+                var packageIndex = new PackageIndex(context);
+
                 if (isSymbols)
                 {
                     symbolsIndex.UnionWith(await symbols.GetSymbolsPackagesAsync());
@@ -448,13 +449,6 @@ namespace SleetLib.Tests
             {
                 var context = testContext.SleetContext;
                 context.SourceSettings.SymbolsEnabled = true;
-                var symbols = new Symbols(context);
-                var packageIndex = new PackageIndex(context);
-                var catalog = new Catalog(context);
-                var autoComplete = new AutoComplete(context);
-                var flatContainer = new FlatContainer(context);
-                var registrations = new Registrations(context);
-                var search = new Search(context);
 
                 // Create package
                 var pkgA = new TestNupkg("a", "1.0.0");
@@ -491,6 +485,14 @@ namespace SleetLib.Tests
 
                 success.Should().BeTrue();
 
+                var symbols = new Symbols(context);
+                var packageIndex = new PackageIndex(context);
+                var catalog = new Catalog(context);
+                var autoComplete = new AutoComplete(context);
+                var flatContainer = new FlatContainer(context);
+                var registrations = new Registrations(context);
+                var search = new Search(context);
+
                 // Exists under symbols
                 (await symbols.GetSymbolsPackagesAsync()).Should().NotBeEmpty();
                 (await packageIndex.GetSymbolsPackagesAsync()).Should().NotBeEmpty();
@@ -523,13 +525,6 @@ namespace SleetLib.Tests
             {
                 var context = testContext.SleetContext;
                 context.SourceSettings.SymbolsEnabled = true;
-                var symbols = new Symbols(context);
-                var packageIndex = new PackageIndex(context);
-                var catalog = new Catalog(context);
-                var autoComplete = new AutoComplete(context);
-                var flatContainer = new FlatContainer(context);
-                var registrations = new Registrations(context);
-                var search = new Search(context);
 
                 // Create package
                 var pkgA = new TestNupkg("a", "1.0.0");
@@ -562,6 +557,9 @@ namespace SleetLib.Tests
                     testContext.SleetContext.Log);
 
                 success.Should().BeTrue();
+
+                var symbols = new Symbols(context);
+                var packageIndex = new PackageIndex(context);
 
                 // The nupkg should exist, but there should not be any assets added.
                 (await symbols.GetSymbolsPackagesAsync()).Should().BeEmpty();


### PR DESCRIPTION
File systems track ISleetFiles in memory which point to files in the local cache. If the same file system is reused between commands/locks it can become out of date and will end up using older versions of files. To avoid this the file system should be reset after each lock. Files taken from before the reset should be invalidated and should fail when used to avoid problems.

//cc @jcagme  this should help avoid problems like the ones you hit for delete and earlier with reading the package index before the lock and then pushing.