### PR TITLE
Add capabilities to determine client/feed compat

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,5 +1,10 @@
 # Release Notes
 
+## 3.0.0
+* Removed client/feed version compat checks based on the minor version of sleet.
+* Added capabilities for client/feed compat checks.
+* Remove netstandard1.0
+
 ## 2.3.75
 * Added Download command options: --no-lock --skip-existing --ignore-errors
 * Skip package SHA512 hashing when the catalog is disabled. Package details blobs will no longer write this extra property.

--- a/src/SleetLib/AssemblyVersionHelper.cs
+++ b/src/SleetLib/AssemblyVersionHelper.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Reflection;
 using NuGet.Versioning;
 
@@ -29,7 +29,16 @@ namespace Sleet
                 // Read the assembly
                 var assemblyVersion = typeof(AssemblyVersionHelper).GetTypeInfo().Assembly.GetName().Version;
 
-                _version = new SemanticVersion(Math.Max(0, assemblyVersion.Major), Math.Max(0, assemblyVersion.Minor), Math.Max(0, assemblyVersion.Build));
+                // Avoid going lower than 3.0.0. This can happen in some build environments and will fail tests.
+                var lowestPossible = new SemanticVersion(3, 0, 0);
+                var tempVersion = new SemanticVersion(Math.Max(0, assemblyVersion.Major), Math.Max(0, assemblyVersion.Minor), Math.Max(0, assemblyVersion.Build));
+
+                if (tempVersion < lowestPossible)
+                {
+                    tempVersion = lowestPossible;
+                }
+
+                _version = tempVersion;
             }
 
             return _version;

--- a/src/SleetLib/Commands/DownloadCommand.cs
+++ b/src/SleetLib/Commands/DownloadCommand.cs
@@ -39,7 +39,7 @@ namespace Sleet
                         feedLock = await SourceUtility.VerifyInitAndLock(settings, source, "Download", log, token);
 
                         // Validate source
-                        await UpgradeUtility.EnsureFeedVersionMatchesTool(source, log, token);
+                        await UpgradeUtility.EnsureCompatibility(source, log, token);
                     }
 
                     success = await DownloadPackages(settings, source, outputPath, ignoreErrors, log, token);

--- a/src/SleetLib/Commands/FeedSettingsCommand.cs
+++ b/src/SleetLib/Commands/FeedSettingsCommand.cs
@@ -32,9 +32,9 @@ namespace Sleet
             using (var feedLock = await SourceUtility.VerifyInitAndLock(settings, source, "Feed settings", log, token))
             {
                 // Validate source
-                var success = await UpgradeUtility.EnsureFeedVersionMatchesTool(source, log, token);
+                await UpgradeUtility.EnsureCompatibility(source, log, token);
 
-                success &= await ApplySettingsAsync(source, unsetAll, getAll, getSettings, unsetSettings, setSettings, log, token);
+                var success = await ApplySettingsAsync(source, unsetAll, getAll, getSettings, unsetSettings, setSettings, log, token);
 
                 log.LogMinimal($"Run 'recreate' to rebuild the feed with the new settings.");
 

--- a/src/SleetLib/Commands/RecreateCommand.cs
+++ b/src/SleetLib/Commands/RecreateCommand.cs
@@ -36,7 +36,7 @@ namespace Sleet
                 if (!force)
                 {
                     // Validate source
-                    await UpgradeUtility.EnsureFeedVersionMatchesTool(source, allowNewer: true, log: log, token: token);
+                    await UpgradeUtility.EnsureCompatibility(source, log: log, token: token);
                 }
 
                 // Read settings and persist them in the new feed.

--- a/src/SleetLib/Commands/StatsCommand.cs
+++ b/src/SleetLib/Commands/StatsCommand.cs
@@ -20,7 +20,7 @@ namespace Sleet
             using (var feedLock = await SourceUtility.VerifyInitAndLock(settings, source, "Stats", log, token))
             {
                 // Validate source
-                await UpgradeUtility.EnsureFeedVersionMatchesTool(source, log, token);
+                await UpgradeUtility.EnsureCompatibility(source, log, token);
 
                 // Get sleet.settings.json
                 var sourceSettings = await FeedSettingsUtility.GetSettingsOrDefault(source, log, token);

--- a/src/SleetLib/Models/FeedCapability.cs
+++ b/src/SleetLib/Models/FeedCapability.cs
@@ -1,0 +1,26 @@
+using NuGet.Versioning;
+
+namespace Sleet
+{
+    public class FeedCapability
+    {
+        public string Name { get; set; }
+
+        public SemanticVersion Version { get; set; }
+
+        public override string ToString()
+        {
+            return $"{Name}:{Version.ToNormalizedString()}".ToLowerInvariant();
+        }
+
+        public static FeedCapability Parse(string s)
+        {
+            var parts = s.ToLowerInvariant().Split(':');
+            return new FeedCapability
+            {
+                Name = parts[0],
+                Version = parts.Length > 0 ? SemanticVersion.Parse(parts[1]) : new SemanticVersion(1, 0, 0)
+            };
+        }
+    }
+}

--- a/src/SleetLib/Models/FeedRequirements.cs
+++ b/src/SleetLib/Models/FeedRequirements.cs
@@ -1,0 +1,26 @@
+using System.Collections.Generic;
+using NuGet.Versioning;
+
+namespace Sleet
+{
+    public class FeedRequirements
+    {
+        /// <summary>
+        /// Original version of sleet used to create the feed. This is deprecated as a means for
+        /// checking if an upgrade is needed.
+        /// </summary>
+        public SemanticVersion CreatorSleetVersion { get; set; } = new SemanticVersion(1, 0, 0);
+
+        /// <summary>
+        /// Required version sleet to work with the feed. The simpliest way to exclude older clients from the feed.
+        /// </summary>
+        public VersionRange RequiredVersion { get; set; } = VersionRange.All;
+
+        /// <summary>
+        /// Required capabilities. This offers fined grained control over when an upgrade is required. If a new
+        /// feature is added to Sleet but not used in the feed we can avoid upgrading by looking for capabilities
+        /// that are not supported.
+        /// </summary>
+        public List<FeedCapability> RequiredCapabilities { get; set; } = new List<FeedCapability>();
+    }
+}

--- a/src/SleetLib/SleetLib.csproj
+++ b/src/SleetLib/SleetLib.csproj
@@ -1,4 +1,4 @@
-﻿<Project ToolsVersion="15.0">
+<Project ToolsVersion="15.0">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\build\common\common.props" />
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
   <PropertyGroup Condition=" '$(IsXPlat)' != 'true' ">

--- a/src/SleetLib/Utility/SourceUtility.cs
+++ b/src/SleetLib/Utility/SourceUtility.cs
@@ -119,7 +119,7 @@ namespace Sleet
         /// </summary>
         public static async Task ValidateFeedForClient(ISleetFileSystem fileSystem, ILogger log, CancellationToken token)
         {
-            await UpgradeUtility.EnsureFeedVersionMatchesTool(fileSystem, log, token);
+            await UpgradeUtility.EnsureCompatibility(fileSystem, log, token);
             await EnsureBaseUriMatchesFeed(fileSystem, log, token);
         }
 

--- a/src/SleetLib/Utility/UpgradeUtility.cs
+++ b/src/SleetLib/Utility/UpgradeUtility.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Common;
@@ -8,85 +10,138 @@ namespace Sleet
 {
     public static class UpgradeUtility
     {
+
+
         /// <summary>
-        /// Override this to set the tool version instead of reading the assembly.
+        /// Currently supported capabilities. New optional features can be added here if they need to block older clients.
+        /// This is an alternative to blocking all older versions of Sleet from a feed with requiredVersion.
         /// </summary>
-        public static SemanticVersion OverrideSleetVersion = null;
+        public static List<FeedCapability> SupportedFeedCapabilities = new List<FeedCapability>()
+        {
+            FeedCapability.Parse("schema:1.0.0")
+        };
+
 
         /// <summary>
         /// Read the assembly version.
         /// </summary>
-        public static async Task<SemanticVersion> GetSleetVersionAsync(ISleetFileSystem fileSystem, ILogger log, CancellationToken token)
+        public static async Task<FeedRequirements> GetFeedRequirementsAsync(ISleetFileSystem fileSystem, ILogger log, CancellationToken token)
         {
-            // Check for override
-            if (OverrideSleetVersion != null)
-            {
-                return OverrideSleetVersion;
-            }
+            var requirements = new FeedRequirements();
 
+            // Read feed index.json data
             var indexPath = fileSystem.Get("index.json");
             var json = await indexPath.GetJson(log, token);
+
             var sleetVersion = json.GetValue("sleet:version")?.ToString();
-            if (!SemanticVersion.TryParse(sleetVersion, out var version))
+            if (!string.IsNullOrEmpty(sleetVersion))
             {
-                throw new InvalidOperationException("Invalid sleet:version in index.json");
+                if (!SemanticVersion.TryParse(sleetVersion, out var version))
+                {
+                    throw new InvalidOperationException("Invalid sleet:version in index.json");
+                }
+
+                requirements.CreatorSleetVersion = version;
             }
 
-            return version;
+            var requiredVersion = json.GetValue("sleet:requiredVersion")?.ToString();
+            if (!string.IsNullOrEmpty(requiredVersion))
+            {
+                if (!VersionRange.TryParse(requiredVersion, out var range))
+                {
+                    throw new InvalidOperationException("Invalid sleet:requiredVersion in index.json");
+                }
+
+                requirements.RequiredVersion = range;
+            }
+
+            var requiredCaps = json.GetValue("sleet:capabilities")?.ToString();
+            if (!string.IsNullOrEmpty(requiredCaps))
+            {
+                // Space delimited list of caps
+                foreach (var s in requiredCaps.Split(new char[] { ' ' }, StringSplitOptions.RemoveEmptyEntries))
+                {
+                    requirements.RequiredCapabilities.Add(FeedCapability.Parse(s));
+                }
+            }
+
+            return requirements;
         }
 
         /// <summary>
         /// Throw if the tool versions does not match the feed.
         /// </summary>
-        public static Task<bool> EnsureFeedVersionMatchesTool(ISleetFileSystem fileSystem, ILogger log, CancellationToken token)
+        public static async Task EnsureCompatibility(ISleetFileSystem fileSystem, ILogger log, CancellationToken token)
         {
-            return EnsureFeedVersionMatchesTool(fileSystem, allowNewer: false, log: log, token: token);
-        }
-
-        /// <summary>
-        /// Throw if the tool versions does not match the feed.
-        /// </summary>
-        public static async Task<bool> EnsureFeedVersionMatchesTool(ISleetFileSystem fileSystem, bool allowNewer, ILogger log, CancellationToken token)
-        {
-            var sourceVersion = await GetSleetVersionAsync(fileSystem, log, token);
+            var requirements = await GetFeedRequirementsAsync(fileSystem, log, token);
+            AddDefaultCapabilities(requirements);
 
             var originalVersion = AssemblyVersionHelper.GetVersion();
             var assemblyVersion = new NuGetVersion(originalVersion.Major, originalVersion.Minor, originalVersion.Patch);
 
-            // Allow all X.Y.* versions to be used, patches should only contain bug fixes
-            // no breaking changes or new features.
-            var allowedRange = GetAllowedRange(sourceVersion, allowNewer);
-
-            if (!allowedRange.Satisfies(assemblyVersion))
+            // Check if a newer client is needed for the feed
+            if (!requirements.RequiredVersion.Satisfies(assemblyVersion))
             {
-                if (sourceVersion < assemblyVersion)
-                {
-                    throw new InvalidOperationException($"{fileSystem.BaseURI} uses an older version of Sleet: {sourceVersion}. Upgrade the feed to {assemblyVersion} by running 'Sleet recreate' against this feed.");
-                }
-                else if (sourceVersion > assemblyVersion)
-                {
-                    throw new InvalidOperationException($"{fileSystem.BaseURI} was created using a newer version of Sleet: {sourceVersion}. Use the same or higher version to make changes.");
-                }
+                throw new InvalidOperationException($"{fileSystem.BaseURI} requires Sleet version: {requirements.RequiredVersion.PrettyPrint()}  Upgrade your Sleet client to work with this feed.");
             }
 
-            return true;
+            var compareResult = CompareCapabilities(SupportedFeedCapabilities, requirements.RequiredCapabilities);
+            if (compareResult < 0)
+            {
+                throw new InvalidOperationException($"{fileSystem.BaseURI} requires a newer version of Sleet. Upgrade your Sleet client to work with this feed.");
+            }
+            else if (compareResult > 0)
+            {
+                throw new InvalidOperationException($"{fileSystem.BaseURI} uses an older version of Sleet: {requirements.CreatorSleetVersion.ToNormalizedString()}. Upgrade the feed to {assemblyVersion} by running 'Sleet recreate' against this feed.");
+            }
         }
 
         /// <summary>
-        /// Get the range of tool versions that can work with the source.
+        /// -1 if the client needs to upgrade (supported caps are lower)
+        /// 0 if the client and feed can work together.
+        /// 1 if the feed requires an upgrade due to being incompatible with the newer client
         /// </summary>
-        public static VersionRange GetAllowedRange(SemanticVersion sourceVersion, bool allowNewer)
+        private static int CompareCapabilities(List<FeedCapability> supportedCaps, List<FeedCapability> requiredCaps)
         {
-            var minVersion = new NuGetVersion(sourceVersion.Major, sourceVersion.Minor, 0);
-            var maxVersion = allowNewer ? null : new NuGetVersion(sourceVersion.Major, sourceVersion.Minor + 1, 0);
+            foreach (var cap in requiredCaps)
+            {
+                var supportedCap = supportedCaps.FirstOrDefault(e => StringComparer.OrdinalIgnoreCase.Equals(e.Name, cap.Name));
 
-            // Create a range that allows any patch version to be used.
-            // If allowNewer is set then allow an open range.
-            return new VersionRange(
-                minVersion: minVersion,
-                includeMinVersion: true,
-                maxVersion: maxVersion,
-                includeMaxVersion: false);
+                if (supportedCap == null)
+                {
+                    // The feed is newer
+                    return -1;
+                }
+
+                // Versions must be an exact match
+                var result = VersionComparer.Compare(supportedCap.Version, cap.Version, VersionComparison.Version);
+
+                if (result != 0)
+                {
+                    return result;
+                }
+            }
+
+            return 0;
+        }
+
+        /// <summary>
+        /// Add default capabilities if none are provided.
+        /// </summary>
+        public static void AddDefaultCapabilities(FeedRequirements requirements)
+        {
+            // Infer default schema from Sleet 2.2.x if none is provided.
+            if (requirements.RequiredCapabilities.Count < 1)
+            {
+                if (requirements.CreatorSleetVersion < new SemanticVersion(2, 2, 0))
+                {
+                    requirements.RequiredCapabilities.Add(FeedCapability.Parse("schema:0.1.0"));
+                }
+                else
+                {
+                    requirements.RequiredCapabilities.Add(FeedCapability.Parse("schema:1.0.0"));
+                }
+            }
         }
     }
 }

--- a/test/SleetLib.Tests/UpgradeUtilityTests.cs
+++ b/test/SleetLib.Tests/UpgradeUtilityTests.cs
@@ -1,5 +1,10 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 using FluentAssertions;
-using NuGet.Versioning;
+using Newtonsoft.Json.Linq;
+using NuGet.Test.Helpers;
 using Sleet;
 using Xunit;
 
@@ -8,21 +13,355 @@ namespace SleetLib.Tests
     public class UpgradeUtilityTests
     {
         [Fact]
-        public void GivenAVersionVerifyAllowedRange()
+        public async Task UpgradeUtility_Verify220FeedsAreCompatibleAsync()
         {
-            UpgradeUtility.GetAllowedRange(new SemanticVersion(1, 2, 3), allowNewer: false)
-                .ToNormalizedString()
-                .Should()
-                .Be("[1.2.0, 1.3.0)");
+            using (var packagesFolder = new TestFolder())
+            using (var target = new TestFolder())
+            using (var cache = new LocalCache())
+            {
+                var log = new TestLogger();
+                var fileSystem = new PhysicalFileSystem(cache, UriUtility.CreateUri(target.Root));
+                var settings = new LocalSettings();
+
+                var context = new SleetContext()
+                {
+                    Token = CancellationToken.None,
+                    LocalSettings = settings,
+                    Log = log,
+                    Source = fileSystem,
+                    SourceSettings = new FeedSettings()
+                    {
+                        CatalogEnabled = true
+                    }
+                };
+
+                // Init
+                await InitCommand.InitAsync(context);
+
+                // Change index.json
+                var indexJsonPath = Path.Combine(target.Root, "index.json");
+                var json = JObject.Parse(File.ReadAllText(indexJsonPath));
+                json["sleet:version"] = "2.2.1";
+                File.WriteAllText(indexJsonPath, json.ToString());
+
+                // Verify no exceptions
+                var fileSystem2 = new PhysicalFileSystem(cache, UriUtility.CreateUri(target.Root));
+                await UpgradeUtility.EnsureCompatibility(fileSystem2, log, CancellationToken.None);
+            }
         }
 
         [Fact]
-        public void GivenAVersionVerifyAllowedRangeHasNoUpperBound()
+        public async Task UpgradeUtility_Verify210FeedsAreNotCompatibleAsync()
         {
-            UpgradeUtility.GetAllowedRange(new SemanticVersion(1, 2, 3), allowNewer: true)
-                .ToNormalizedString()
-                .Should()
-                .Be("[1.2.0, )");
+            using (var packagesFolder = new TestFolder())
+            using (var target = new TestFolder())
+            using (var cache = new LocalCache())
+            {
+                var log = new TestLogger();
+                var fileSystem = new PhysicalFileSystem(cache, UriUtility.CreateUri(target.Root));
+                var settings = new LocalSettings();
+
+                var context = new SleetContext()
+                {
+                    Token = CancellationToken.None,
+                    LocalSettings = settings,
+                    Log = log,
+                    Source = fileSystem,
+                    SourceSettings = new FeedSettings()
+                    {
+                        CatalogEnabled = true
+                    }
+                };
+
+                // Init
+                await InitCommand.InitAsync(context);
+
+                // Change index.json
+                var indexJsonPath = Path.Combine(target.Root, "index.json");
+                var json = JObject.Parse(File.ReadAllText(indexJsonPath));
+                json["sleet:version"] = "2.1.1";
+                File.WriteAllText(indexJsonPath, json.ToString());
+
+                Exception ex = null;
+                try
+                {
+                    var fileSystem2 = new PhysicalFileSystem(cache, UriUtility.CreateUri(target.Root));
+                    await UpgradeUtility.EnsureCompatibility(fileSystem2, log, CancellationToken.None);
+                }
+                catch (Exception current)
+                {
+                    ex = current;
+                }
+
+                ex.Should().NotBeNull();
+                ex.Message.Should().Contain("Sleet recreate");
+            }
+        }
+
+        [Fact]
+        public async Task UpgradeUtility_VerifyRequiredVersionFailsForOlderVersionAsync()
+        {
+            using (var packagesFolder = new TestFolder())
+            using (var target = new TestFolder())
+            using (var cache = new LocalCache())
+            {
+                var log = new TestLogger();
+                var fileSystem = new PhysicalFileSystem(cache, UriUtility.CreateUri(target.Root));
+                var settings = new LocalSettings();
+
+                var context = new SleetContext()
+                {
+                    Token = CancellationToken.None,
+                    LocalSettings = settings,
+                    Log = log,
+                    Source = fileSystem,
+                    SourceSettings = new FeedSettings()
+                    {
+                        CatalogEnabled = true
+                    }
+                };
+
+                // Init
+                await InitCommand.InitAsync(context);
+
+                // Change index.json
+                var indexJsonPath = Path.Combine(target.Root, "index.json");
+                var json = JObject.Parse(File.ReadAllText(indexJsonPath));
+                json["sleet:requiredVersion"] = "4.1.0";
+                File.WriteAllText(indexJsonPath, json.ToString());
+
+                Exception ex = null;
+                try
+                {
+                    var fileSystem2 = new PhysicalFileSystem(cache, UriUtility.CreateUri(target.Root));
+                    await UpgradeUtility.EnsureCompatibility(fileSystem2, log, CancellationToken.None);
+                }
+                catch (Exception current)
+                {
+                    ex = current;
+                }
+
+                ex.Should().NotBeNull();
+                ex.Message.Should().Contain("requires Sleet version: (>= 4.1.0)  Upgrade your Sleet client to work with this feed.");
+            }
+        }
+
+        [Fact]
+        public async Task UpgradeUtility_VerifyRequiredVersionWorksForNewerVersionAsync()
+        {
+            using (var packagesFolder = new TestFolder())
+            using (var target = new TestFolder())
+            using (var cache = new LocalCache())
+            {
+                var log = new TestLogger();
+                var fileSystem = new PhysicalFileSystem(cache, UriUtility.CreateUri(target.Root));
+                var settings = new LocalSettings();
+
+                var context = new SleetContext()
+                {
+                    Token = CancellationToken.None,
+                    LocalSettings = settings,
+                    Log = log,
+                    Source = fileSystem,
+                    SourceSettings = new FeedSettings()
+                    {
+                        CatalogEnabled = true
+                    }
+                };
+
+                // Init
+                await InitCommand.InitAsync(context);
+
+                // Change index.json
+                var indexJsonPath = Path.Combine(target.Root, "index.json");
+                var json = JObject.Parse(File.ReadAllText(indexJsonPath));
+                json["sleet:requiredVersion"] = "2.3.0";
+                File.WriteAllText(indexJsonPath, json.ToString());
+
+                var fileSystem2 = new PhysicalFileSystem(cache, UriUtility.CreateUri(target.Root));
+                await UpgradeUtility.EnsureCompatibility(fileSystem2, log, CancellationToken.None);
+            }
+        }
+
+        [Fact]
+        public async Task UpgradeUtility_VerifyUnknownCapabilityFailsAsync()
+        {
+            using (var packagesFolder = new TestFolder())
+            using (var target = new TestFolder())
+            using (var cache = new LocalCache())
+            {
+                var log = new TestLogger();
+                var fileSystem = new PhysicalFileSystem(cache, UriUtility.CreateUri(target.Root));
+                var settings = new LocalSettings();
+
+                var context = new SleetContext()
+                {
+                    Token = CancellationToken.None,
+                    LocalSettings = settings,
+                    Log = log,
+                    Source = fileSystem,
+                    SourceSettings = new FeedSettings()
+                    {
+                        CatalogEnabled = true
+                    }
+                };
+
+                // Init
+                await InitCommand.InitAsync(context);
+
+                // Change index.json
+                var indexJsonPath = Path.Combine(target.Root, "index.json");
+                var json = JObject.Parse(File.ReadAllText(indexJsonPath));
+                json["sleet:capabilities"] = "newfeature:10.0.0";
+                File.WriteAllText(indexJsonPath, json.ToString());
+
+                Exception ex = null;
+                try
+                {
+                    var fileSystem2 = new PhysicalFileSystem(cache, UriUtility.CreateUri(target.Root));
+                    await UpgradeUtility.EnsureCompatibility(fileSystem2, log, CancellationToken.None);
+                }
+                catch (Exception current)
+                {
+                    ex = current;
+                }
+
+                ex.Should().NotBeNull();
+                ex.Message.Should().Contain("requires a newer version of Sleet. Upgrade your Sleet client to work with this feed.");
+            }
+        }
+
+        [Fact]
+        public async Task UpgradeUtility_VerifyHigherVersionOfCapabilityFailsAsync()
+        {
+            using (var packagesFolder = new TestFolder())
+            using (var target = new TestFolder())
+            using (var cache = new LocalCache())
+            {
+                var log = new TestLogger();
+                var fileSystem = new PhysicalFileSystem(cache, UriUtility.CreateUri(target.Root));
+                var settings = new LocalSettings();
+
+                var context = new SleetContext()
+                {
+                    Token = CancellationToken.None,
+                    LocalSettings = settings,
+                    Log = log,
+                    Source = fileSystem,
+                    SourceSettings = new FeedSettings()
+                    {
+                        CatalogEnabled = true
+                    }
+                };
+
+                // Init
+                await InitCommand.InitAsync(context);
+
+                // Change index.json
+                var indexJsonPath = Path.Combine(target.Root, "index.json");
+                var json = JObject.Parse(File.ReadAllText(indexJsonPath));
+                json["sleet:capabilities"] = "schema:99999.9999.9999";
+                File.WriteAllText(indexJsonPath, json.ToString());
+
+                Exception ex = null;
+                try
+                {
+                    var fileSystem2 = new PhysicalFileSystem(cache, UriUtility.CreateUri(target.Root));
+                    await UpgradeUtility.EnsureCompatibility(fileSystem2, log, CancellationToken.None);
+                }
+                catch (Exception current)
+                {
+                    ex = current;
+                }
+
+                ex.Should().NotBeNull();
+                ex.Message.Should().Contain("requires a newer version of Sleet. Upgrade your Sleet client to work with this feed.");
+            }
+        }
+
+        [Fact]
+        public async Task UpgradeUtility_VerifyLowerVersionOfCapabilityFailsAsync()
+        {
+            using (var packagesFolder = new TestFolder())
+            using (var target = new TestFolder())
+            using (var cache = new LocalCache())
+            {
+                var log = new TestLogger();
+                var fileSystem = new PhysicalFileSystem(cache, UriUtility.CreateUri(target.Root));
+                var settings = new LocalSettings();
+
+                var context = new SleetContext()
+                {
+                    Token = CancellationToken.None,
+                    LocalSettings = settings,
+                    Log = log,
+                    Source = fileSystem,
+                    SourceSettings = new FeedSettings()
+                    {
+                        CatalogEnabled = true
+                    }
+                };
+
+                // Init
+                await InitCommand.InitAsync(context);
+
+                // Change index.json
+                var indexJsonPath = Path.Combine(target.Root, "index.json");
+                var json = JObject.Parse(File.ReadAllText(indexJsonPath));
+                json["sleet:capabilities"] = "schema:0.0.0";
+                File.WriteAllText(indexJsonPath, json.ToString());
+
+                Exception ex = null;
+                try
+                {
+                    var fileSystem2 = new PhysicalFileSystem(cache, UriUtility.CreateUri(target.Root));
+                    await UpgradeUtility.EnsureCompatibility(fileSystem2, log, CancellationToken.None);
+                }
+                catch (Exception current)
+                {
+                    ex = current;
+                }
+
+                ex.Should().NotBeNull();
+                ex.Message.Should().Contain("by running 'Sleet recreate' against this feed.");
+            }
+        }
+
+        [Fact]
+        public async Task UpgradeUtility_VerifyMatchingVersionOfCapabilityWorksAsync()
+        {
+            using (var packagesFolder = new TestFolder())
+            using (var target = new TestFolder())
+            using (var cache = new LocalCache())
+            {
+                var log = new TestLogger();
+                var fileSystem = new PhysicalFileSystem(cache, UriUtility.CreateUri(target.Root));
+                var settings = new LocalSettings();
+
+                var context = new SleetContext()
+                {
+                    Token = CancellationToken.None,
+                    LocalSettings = settings,
+                    Log = log,
+                    Source = fileSystem,
+                    SourceSettings = new FeedSettings()
+                    {
+                        CatalogEnabled = true
+                    }
+                };
+
+                // Init
+                await InitCommand.InitAsync(context);
+
+                // Change index.json
+                var indexJsonPath = Path.Combine(target.Root, "index.json");
+                var json = JObject.Parse(File.ReadAllText(indexJsonPath));
+                json["sleet:capabilities"] = "schema:1.0.0";
+                File.WriteAllText(indexJsonPath, json.ToString());
+
+                var fileSystem2 = new PhysicalFileSystem(cache, UriUtility.CreateUri(target.Root));
+                await UpgradeUtility.EnsureCompatibility(fileSystem2, log, CancellationToken.None);
+            }
         }
     }
 }


### PR DESCRIPTION
This change removes the previous logic that compared the assembly version
to sleet:version in index.json. Capabilities support fine grained control
over compatibility based on what features in the feed are actually used.

Support for sleet:requiredVersion has also been added to limit the feed to
certain sleet client versions if needed.

After this change Sleet will be able to version itself in a helpful way for
users without breaking compatibility with older feeds that will still work fine.