### PR TITLE
Auto initialize new feeds

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,9 +1,11 @@
 # Release Notes
 
 ## 3.0.0
+* Init command will now automatically create a public bucket/container if it does not exist already. *breaking change*
+* Push command will now automatically create a public bucket/container and initialize a feed using the default settings if it does not exist already. *breaking change*
 * Removed client/feed version compat checks based on the minor version of sleet.
 * Added capabilities for client/feed compat checks.
-* Remove netstandard1.0
+* Remove netstandard1.0 *breaking change*
 
 ## 2.3.75
 * Added Download command options: --no-lock --skip-existing --ignore-errors

--- a/src/SleetLib/Commands/InitCommand.cs
+++ b/src/SleetLib/Commands/InitCommand.cs
@@ -30,9 +30,15 @@ namespace Sleet
             return InitAsync(context.LocalSettings, context.Source, context.SourceSettings, context.Log, context.Token);
         }
 
-        public static async Task<bool> InitAsync(LocalSettings settings, ISleetFileSystem source, FeedSettings feedSettings, ILogger log, CancellationToken token)
+        public static Task<bool> InitAsync(LocalSettings settings, ISleetFileSystem source, FeedSettings feedSettings, ILogger log, CancellationToken token)
+        {
+            return InitAsync(settings, source, feedSettings, autoCreateBucket: true, log: log, token: token);
+        }
+
+        public static async Task<bool> InitAsync(LocalSettings settings, ISleetFileSystem source, FeedSettings feedSettings, bool autoCreateBucket, ILogger log, CancellationToken token)
         {
             SourceUtility.ValidateFileSystem(source);
+            await SourceUtility.EnsureBucketOrThrow(source, autoCreateBucket, log, token);
 
             var exitCode = true;
             var noChanges = true;

--- a/src/SleetLib/Commands/PushCommand.cs
+++ b/src/SleetLib/Commands/PushCommand.cs
@@ -49,8 +49,9 @@ namespace Sleet
                                 lockMessage = $"Push of {packages[0].Identity.ToString()}";
                             }
 
-                            // Check if already initialized
-                            feedLock = await SourceUtility.VerifyInitAndLock(settings, source, lockMessage, log, token);
+                            // Create and initialize the feed if it is new.
+                            // Lock the feed before running push.
+                            feedLock = await SourceUtility.InitAndLock(settings, source, lockMessage, autoCreateBucket: true, autoInit: true, log: log, token: token);
 
                             // Validate source
                             await SourceUtility.ValidateFeedForClient(source, log, token);

--- a/src/SleetLib/FileSystem/AmazonS3FileSystem.cs
+++ b/src/SleetLib/FileSystem/AmazonS3FileSystem.cs
@@ -5,6 +5,8 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Amazon.S3;
+using Amazon.S3.Model;
+using Newtonsoft.Json.Linq;
 using NuGet.Common;
 using static Sleet.AmazonS3FileSystemAbstraction;
 
@@ -42,7 +44,7 @@ namespace Sleet
         {
             log.LogInformation($"Verifying {bucketName} exists.");
 
-            var isBucketFound = await client.DoesS3BucketExistAsync(bucketName).ConfigureAwait(false);
+            var isBucketFound = await HasBucket(log, token);
             if (!isBucketFound)
             {
                 log.LogError(
@@ -89,6 +91,48 @@ namespace Sleet
             }
 
             return relativePath;
+        }
+
+        public override async Task<bool> HasBucket(ILogger log, CancellationToken token)
+        {
+            return await client.DoesS3BucketExistAsync(bucketName);
+        }
+
+        public override async Task CreateBucket(ILogger log, CancellationToken token)
+        {
+            await client.EnsureBucketExistsAsync(bucketName);
+
+            var policyRequest = new PutBucketPolicyRequest()
+            {
+                BucketName = bucketName,
+                Policy = GetReadOnlyPolicy(bucketName).ToString()
+            };
+
+            await client.PutBucketPolicyAsync(policyRequest);
+        }
+
+        public override async Task DeleteBucket(ILogger log, CancellationToken token)
+        {
+            if (await HasBucket(log, token))
+            {
+                await client.DeleteBucketAsync(bucketName, token);
+            }
+        }
+
+        private static JObject GetReadOnlyPolicy(string bucketName)
+        {
+            // Grant read-only access based on https://aws.amazon.com/premiumsupport/knowledge-center/read-access-objects-s3-bucket/
+            return new JObject(
+                new JProperty("Version", "2012-10-17"),
+                new JProperty("Statement",
+                    new JArray(
+                        new JObject(
+                            new JProperty("Sid", "AllowPublicRead"),
+                            new JProperty("Effect", "Allow"),
+                            new JProperty("Principal", "*"),
+                            new JProperty("Action", new JArray("s3:GetObject")),
+                            new JProperty("Resource", new JArray($"arn:aws:s3:::{bucketName}/*"))
+                        ))));
         }
     }
 }

--- a/src/SleetLib/FileSystem/AzureFileSystem.cs
+++ b/src/SleetLib/FileSystem/AzureFileSystem.cs
@@ -127,5 +127,20 @@ namespace Sleet
 
             return relativePath;
         }
+
+        public override Task<bool> HasBucket(ILogger log, CancellationToken token)
+        {
+            return _container.ExistsAsync(token);
+        }
+
+        public override async Task CreateBucket(ILogger log, CancellationToken token)
+        {
+            await _container.CreateIfNotExistsAsync(BlobContainerPublicAccessType.Blob, null, null, token);
+        }
+
+        public override async Task DeleteBucket(ILogger log, CancellationToken token)
+        {
+            await _container.DeleteIfExistsAsync(token);
+        }
     }
 }

--- a/src/SleetLib/FileSystem/FileSystemBase.cs
+++ b/src/SleetLib/FileSystem/FileSystemBase.cs
@@ -229,5 +229,11 @@ namespace Sleet
             // Clear all tracked filed
             Files.Clear();
         }
+
+        public abstract Task<bool> HasBucket(ILogger log, CancellationToken token);
+
+        public abstract Task CreateBucket(ILogger log, CancellationToken token);
+
+        public abstract Task DeleteBucket(ILogger log, CancellationToken token);
     }
 }

--- a/src/SleetLib/FileSystem/ISleetFileSystem.cs
+++ b/src/SleetLib/FileSystem/ISleetFileSystem.cs
@@ -53,5 +53,20 @@ namespace Sleet
         /// Reset the file system and clear all tracked and cached files.
         /// </summary>
         void Reset();
+
+        /// <summary>
+        /// True if the folder/container/bucket exists.
+        /// </summary>
+        Task<bool> HasBucket(ILogger log, CancellationToken token);
+
+        /// <summary>
+        /// Create the folder/container/bucket.
+        /// </summary>
+        Task CreateBucket(ILogger log, CancellationToken token);
+
+        /// <summary>
+        /// Delete the folder/container/bucket.
+        /// </summary>
+        Task DeleteBucket(ILogger log, CancellationToken token);
     }
 }

--- a/test/Sleet.AmazonS3.Tests/AmazonS3FileSystemTests.cs
+++ b/test/Sleet.AmazonS3.Tests/AmazonS3FileSystemTests.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using NuGet.Test.Helpers;
+using Sleet.Test.Common;
+
+namespace Sleet.AmazonS3.Tests
+{
+    public class AmazonS3FileSystemTests
+    {
+        [EnvVarExistsFact(AmazonS3TestContext.EnvAccessKeyId)]
+        public async Task GivenAS3AccountVerifyBucketOperations()
+        {
+            using (var testContext = new AmazonS3TestContext())
+            {
+                testContext.CreateBucketOnInit = false;
+                await testContext.InitAsync();
+
+                // Verify at the start
+                (await testContext.FileSystem.HasBucket(testContext.Logger, CancellationToken.None)).Should().BeFalse();
+                (await testContext.FileSystem.Validate(testContext.Logger, CancellationToken.None)).Should().BeFalse();
+
+                // Create
+                await testContext.FileSystem.CreateBucket(testContext.Logger, CancellationToken.None);
+
+                (await testContext.FileSystem.HasBucket(testContext.Logger, CancellationToken.None)).Should().BeTrue();
+                (await testContext.FileSystem.Validate(testContext.Logger, CancellationToken.None)).Should().BeTrue();
+
+                // Delete
+                await testContext.FileSystem.DeleteBucket(testContext.Logger, CancellationToken.None);
+
+                (await testContext.FileSystem.HasBucket(testContext.Logger, CancellationToken.None)).Should().BeFalse();
+                (await testContext.FileSystem.Validate(testContext.Logger, CancellationToken.None)).Should().BeFalse();
+
+                await testContext.CleanupAsync();
+            }
+        }
+    }
+}

--- a/test/Sleet.AmazonS3.Tests/AmazonS3NuGetIntegrationTests.cs
+++ b/test/Sleet.AmazonS3.Tests/AmazonS3NuGetIntegrationTests.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using NuGet.Common;
+using NuGet.Protocol;
+using NuGet.Protocol.Core.Types;
+using NuGet.Test.Helpers;
+using Sleet.Test.Common;
+
+namespace Sleet.AmazonS3.Tests
+{
+    public class AmazonS3NuGetIntegrationTests
+    {
+        [EnvVarExistsFact(AmazonS3TestContext.EnvAccessKeyId)]
+        public async Task GivenPushCreatesAnS3BucketVerifyNuGetCanRead()
+        {
+            using (var packagesFolder = new TestFolder())
+            using (var testContext = new AmazonS3TestContext())
+            using (var sourceContext = new SourceCacheContext())
+            {
+                // Skip creation and allow it to be done during push.
+                testContext.CreateBucketOnInit = false;
+                await testContext.InitAsync();
+
+                var testPackage = new TestNupkg("packageA", "1.0.0");
+                var zipFile = testPackage.Save(packagesFolder.Root);
+
+                var result = await PushCommand.RunAsync(testContext.LocalSettings,
+                    testContext.FileSystem,
+                    new List<string>() { zipFile.FullName },
+                    force: false,
+                    skipExisting: false,
+                    log: testContext.Logger);
+
+                // Read the feed with NuGet.Protocol
+                var feedIndex = $"{testContext.FileSystem.Root.AbsoluteUri}index.json";
+                var repo = Repository.Factory.GetCoreV3(feedIndex);
+                var resource = await repo.GetResourceAsync<FindPackageByIdResource>(CancellationToken.None);
+
+                var packageResults = (await resource.GetAllVersionsAsync("packageA", sourceContext, NullLogger.Instance, CancellationToken.None)).ToList();
+                packageResults.Count.Should().Be(1);
+                packageResults[0].ToIdentityString().Should().Be("1.0.0");
+
+                await testContext.CleanupAsync();
+            }
+        }
+    }
+}

--- a/test/Sleet.AmazonS3.Tests/BasicTests.cs
+++ b/test/Sleet.AmazonS3.Tests/BasicTests.cs
@@ -71,6 +71,66 @@ namespace Sleet.AmazonS3.Tests
         }
 
         [EnvVarExistsFact(AmazonS3TestContext.EnvAccessKeyId)]
+        public async Task GivenAStorageAccountWithNoContainerVerifyPushSucceeds()
+        {
+            using (var packagesFolder = new TestFolder())
+            using (var testContext = new AmazonS3TestContext())
+            {
+                // Skip creation and allow it to be done during push.
+                testContext.CreateBucketOnInit = false;
+
+                await testContext.InitAsync();
+
+                var testPackage = new TestNupkg("packageA", "1.0.0");
+                var zipFile = testPackage.Save(packagesFolder.Root);
+
+                var result = await PushCommand.RunAsync(testContext.LocalSettings,
+                    testContext.FileSystem,
+                    new List<string>() { zipFile.FullName },
+                    force: false,
+                    skipExisting: false,
+                    log: testContext.Logger);
+
+                result &= await ValidateCommand.RunAsync(testContext.LocalSettings,
+                    testContext.FileSystem,
+                    testContext.Logger);
+
+                result.Should().BeTrue();
+
+                await testContext.CleanupAsync();
+            }
+        }
+
+        [EnvVarExistsFact(AmazonS3TestContext.EnvAccessKeyId)]
+        public async Task GivenAStorageAccountWithNoInitVerifyPushSucceeds()
+        {
+            using (var packagesFolder = new TestFolder())
+            using (var testContext = new AmazonS3TestContext())
+            {
+                await testContext.InitAsync();
+
+                var testPackage = new TestNupkg("packageA", "1.0.0");
+                var zipFile = testPackage.Save(packagesFolder.Root);
+
+                // Skip init
+                var result = await PushCommand.RunAsync(testContext.LocalSettings,
+                    testContext.FileSystem,
+                    new List<string>() { zipFile.FullName },
+                    force: false,
+                    skipExisting: false,
+                    log: testContext.Logger);
+
+                result &= await ValidateCommand.RunAsync(testContext.LocalSettings,
+                    testContext.FileSystem,
+                    testContext.Logger);
+
+                result.Should().BeTrue();
+
+                await testContext.CleanupAsync();
+            }
+        }
+
+        [EnvVarExistsFact(AmazonS3TestContext.EnvAccessKeyId)]
         public async Task GivenAStorageAccountVerifyPushAndRemoveSucceed()
         {
             using (var packagesFolder = new TestFolder())

--- a/test/Sleet.AmazonS3.Tests/Sleet.AmazonS3.Tests.csproj
+++ b/test/Sleet.AmazonS3.Tests/Sleet.AmazonS3.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project ToolsVersion="15.0">
+<Project ToolsVersion="15.0">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\build\common\test.props" />
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
 
@@ -12,6 +12,7 @@
     <TestProject>true</TestProject>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="NuGet.Protocol" Version="$(NuGetPackageVersion)" />
     <PackageReference Include="NuGet.Test.Helpers" Version="$(NuGetTestHelpersVersion)" />
   </ItemGroup>
   <ItemGroup>

--- a/test/Sleet.Azure.Tests/AzureFileSystemTests.cs
+++ b/test/Sleet.Azure.Tests/AzureFileSystemTests.cs
@@ -1,0 +1,42 @@
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Sleet.Test.Common;
+
+namespace Sleet.Azure.Tests
+{
+    /// <summary>
+    /// These tests can run locally against developer storage by changing
+    /// EnvVarExistsFactAttribute -> Fact and starting up the emulator.
+    /// </summary>
+    public class AzureFileSystemTests
+    {
+        [EnvVarExistsFact(AzureTestContext.EnvVarName)]
+        public async Task GivenAStorageAccountVerifyContainerOperations()
+        {
+            using (var testContext = new AzureTestContext())
+            {
+                testContext.CreateContainerOnInit = false;
+                await testContext.InitAsync();
+
+                // Verify at the start
+                (await testContext.FileSystem.HasBucket(testContext.Logger, CancellationToken.None)).Should().BeFalse();
+                (await testContext.FileSystem.Validate(testContext.Logger, CancellationToken.None)).Should().BeFalse();
+
+                // Create
+                await testContext.FileSystem.CreateBucket(testContext.Logger, CancellationToken.None);
+
+                (await testContext.FileSystem.HasBucket(testContext.Logger, CancellationToken.None)).Should().BeTrue();
+                (await testContext.FileSystem.Validate(testContext.Logger, CancellationToken.None)).Should().BeTrue();
+
+                // Delete
+                await testContext.FileSystem.DeleteBucket(testContext.Logger, CancellationToken.None);
+
+                (await testContext.FileSystem.HasBucket(testContext.Logger, CancellationToken.None)).Should().BeFalse();
+                (await testContext.FileSystem.Validate(testContext.Logger, CancellationToken.None)).Should().BeFalse();
+
+                await testContext.CleanupAsync();
+            }
+        }
+    }
+}

--- a/test/Sleet.Azure.Tests/AzureNuGetIntegrationTests.cs
+++ b/test/Sleet.Azure.Tests/AzureNuGetIntegrationTests.cs
@@ -1,0 +1,54 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using NuGet.Common;
+using NuGet.Protocol;
+using NuGet.Protocol.Core.Types;
+using NuGet.Test.Helpers;
+using Sleet.Test.Common;
+
+namespace Sleet.Azure.Tests
+{
+    /// <summary>
+    /// These tests can run locally against developer storage by changing
+    /// EnvVarExistsFactAttribute -> Fact and starting up the emulator.
+    /// </summary>
+    public class AzureNuGetIntegrationTests
+    {
+        [EnvVarExistsFact(AzureTestContext.EnvVarName)]
+        public async Task GivenPushCreatesAContainerVerifyNuGetCanRead()
+        {
+            using (var packagesFolder = new TestFolder())
+            using (var testContext = new AzureTestContext())
+            using (var sourceContext = new SourceCacheContext())
+            {
+                // Skip creation and allow it to be done during push.
+                testContext.CreateContainerOnInit = false;
+                await testContext.InitAsync();
+
+                var testPackage = new TestNupkg("packageA", "1.0.0");
+                var zipFile = testPackage.Save(packagesFolder.Root);
+
+                var result = await PushCommand.RunAsync(testContext.LocalSettings,
+                    testContext.FileSystem,
+                    new List<string>() { zipFile.FullName },
+                    force: false,
+                    skipExisting: false,
+                    log: testContext.Logger);
+
+                // Read the feed with NuGet.Protocol
+                var feedIndex = $"{testContext.FileSystem.Root.AbsoluteUri}index.json";
+                var repo = Repository.Factory.GetCoreV3(feedIndex);
+                var resource = await repo.GetResourceAsync<FindPackageByIdResource>(CancellationToken.None);
+
+                var packageResults = (await resource.GetAllVersionsAsync("packageA", sourceContext, NullLogger.Instance, CancellationToken.None)).ToList();
+                packageResults.Count.Should().Be(1);
+                packageResults[0].ToIdentityString().Should().Be("1.0.0");
+
+                await testContext.CleanupAsync();
+            }
+        }
+    }
+}

--- a/test/Sleet.Azure.Tests/AzureTestContext.cs
+++ b/test/Sleet.Azure.Tests/AzureTestContext.cs
@@ -27,9 +27,11 @@ namespace Sleet.Azure.Tests
 
         public ILogger Logger { get; }
 
+        public bool CreateContainerOnInit = true;
+
         public AzureTestContext()
         {
-            ContainerName = Guid.NewGuid().ToString();
+            ContainerName = $"sleet-test-{Guid.NewGuid().ToString()}";
             StorageAccount = CloudStorageAccount.Parse(GetConnectionString());
             BlobClient = StorageAccount.CreateCloudBlobClient();
             Container = BlobClient.GetContainerReference(ContainerName);
@@ -39,9 +41,12 @@ namespace Sleet.Azure.Tests
             Logger = new TestLogger();
         }
 
-        public Task InitAsync()
+        public async Task InitAsync()
         {
-            return Container.CreateIfNotExistsAsync();
+            if (CreateContainerOnInit)
+            {
+                await Container.CreateIfNotExistsAsync();
+            }
         }
 
         private bool _cleanupDone = false;

--- a/test/Sleet.Azure.Tests/Sleet.Azure.Tests.csproj
+++ b/test/Sleet.Azure.Tests/Sleet.Azure.Tests.csproj
@@ -15,6 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="NuGet.Test.Helpers" Version="$(NuGetTestHelpersVersion)" />
+    <PackageReference Include="NuGet.Protocol" Version="$(NuGetPackageVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/SleetLib.Tests/PhysicalFileSystemTests.cs
+++ b/test/SleetLib.Tests/PhysicalFileSystemTests.cs
@@ -403,5 +403,90 @@ namespace SleetLib.Tests
                 File.Exists(extFile.FullName).Should().BeTrue("The original file should not be removed");
             }
         }
+
+        [Fact]
+        public async Task VerifyHasBucketReturnsFalse()
+        {
+            using (var target = new TestFolder())
+            using (var cache = new LocalCache())
+            using (var extCache = new LocalCache())
+            {
+                var log = new TestLogger();
+                var root = Path.Combine(target.RootDirectory.FullName, "testFeed");
+
+                var fileSystem = new PhysicalFileSystem(cache, UriUtility.CreateUri(root));
+                var exists = await fileSystem.HasBucket(log, CancellationToken.None);
+                exists.Should().Be(false);
+            }
+        }
+
+        [Fact]
+        public async Task VerifyHasBucketWithMultipleLevelsReturnsFalse()
+        {
+            using (var target = new TestFolder())
+            using (var cache = new LocalCache())
+            using (var extCache = new LocalCache())
+            {
+                var log = new TestLogger();
+                var root = Path.Combine(target.RootDirectory.FullName, "testParent2/testParent1/testFeed");
+
+                var fileSystem = new PhysicalFileSystem(cache, UriUtility.CreateUri(root));
+                var exists = await fileSystem.HasBucket(log, CancellationToken.None);
+                exists.Should().Be(false);
+            }
+        }
+
+        [Fact]
+        public async Task VerifyCreateBucketCreates()
+        {
+            using (var target = new TestFolder())
+            using (var cache = new LocalCache())
+            using (var extCache = new LocalCache())
+            {
+                var log = new TestLogger();
+                var root = Path.Combine(target.RootDirectory.FullName, "testParent2/testParent1/testFeed");
+
+                var fileSystem = new PhysicalFileSystem(cache, UriUtility.CreateUri(root));
+                await fileSystem.CreateBucket(log, CancellationToken.None);
+                var exists = await fileSystem.HasBucket(log, CancellationToken.None);
+                exists.Should().Be(true);
+            }
+        }
+
+        [Fact]
+        public async Task VerifyDeleteBucketRemovesFolder()
+        {
+            using (var target = new TestFolder())
+            using (var cache = new LocalCache())
+            using (var extCache = new LocalCache())
+            {
+                var log = new TestLogger();
+                var root = Path.Combine(target.RootDirectory.FullName, "testParent2/testParent1/testFeed");
+
+                var fileSystem = new PhysicalFileSystem(cache, UriUtility.CreateUri(root));
+                await fileSystem.CreateBucket(log, CancellationToken.None);
+                await fileSystem.DeleteBucket(log, CancellationToken.None);
+                var exists = await fileSystem.HasBucket(log, CancellationToken.None);
+                exists.Should().Be(false);
+            }
+        }
+
+        [Fact]
+        public async Task VerifyValidate()
+        {
+            using (var target = new TestFolder())
+            using (var cache = new LocalCache())
+            using (var extCache = new LocalCache())
+            {
+                var log = new TestLogger();
+                var root = Path.Combine(target.RootDirectory.FullName, "testParent2/testParent1/testFeed");
+
+                var fileSystem = new PhysicalFileSystem(cache, UriUtility.CreateUri(root));
+
+                (await fileSystem.HasBucket(log, CancellationToken.None)).Should().BeFalse();
+                await fileSystem.CreateBucket(log, CancellationToken.None);
+                (await fileSystem.HasBucket(log, CancellationToken.None)).Should().BeTrue();
+            }
+        }
     }
 }


### PR DESCRIPTION
* Automatically create folders/containers/buckets for new feeds if they do not exist.
* Automatically initialize new feeds if they have not yet been initialized.
* Feeds will be public by default.

This change makes it easier to create feeds as part of build scripts.

Note that this is a breaking change, so it will be part of 3.0.0.