### PR TITLE
Fix bug preventing specifying S3 type on the command line and env vars.

### DIFF
--- a/src/Sleet/CreateConfigAppCommand.cs
+++ b/src/Sleet/CreateConfigAppCommand.cs
@@ -37,7 +37,7 @@ namespace Sleet
 
                 var outputPath = output.HasValue() ? output.Value() : null;
 
-                var storageType = awss3.HasValue() ? FileSystemStorageType.AmazonS3 :
+                var storageType = awss3.HasValue() ? FileSystemStorageType.S3 :
                     azure.HasValue() ? FileSystemStorageType.Azure :
                     folder.HasValue() ? FileSystemStorageType.Local :
                     FileSystemStorageType.Unspecified;

--- a/src/SleetLib/Commands/CreateConfigCommand.cs
+++ b/src/SleetLib/Commands/CreateConfigCommand.cs
@@ -67,7 +67,7 @@ namespace Sleet
                         { "connectionString", AzureFileSystem.AzureEmptyConnectionString }
                     };
                     break;
-                case FileSystemStorageType.AmazonS3:
+                case FileSystemStorageType.S3:
                     storageTemplateJson = new JObject
                     {
                         { "name", "myAmazonS3Feed" },

--- a/src/SleetLib/FileSystem/FileSystemStorageType.cs
+++ b/src/SleetLib/FileSystem/FileSystemStorageType.cs
@@ -1,10 +1,10 @@
-﻿namespace Sleet
+namespace Sleet
 {
     public enum FileSystemStorageType
     {
         Unspecified,
         Local,
         Azure,
-        AmazonS3,
+        S3,
     }
 }


### PR DESCRIPTION
I'm try to run without a config file, passing everything in through the command line.  If I pass in `-p SLEET_FEED_TYPE=S3` the value "s3" doesn't match the enum `FileSystemStorageType.AmazonS3` and so `GetConfigFromEnv` fails to parse the env vars. If I pass in `-p SLEET_FEED_TYPE=AmazonS3`
`CreateFileSystemAsync` returns null because of the line 115 `else if (type == "s3")`