### PR TITLE
Use AWSSDKVersion variable for security token package

### DIFF
--- a/src/SleetLib/SleetLib.csproj
+++ b/src/SleetLib/SleetLib.csproj
@@ -31,7 +31,7 @@
 
   <ItemGroup>
     <PackageReference Include="AWSSDK.S3" Version="$(AWSSDKVersion)" />
-    <PackageReference Include="AWSSDK.SecurityToken" Version="3.3.102.28" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="$(AWSSDKVersion)" />
     <PackageReference Include="NuGet.Packaging" Version="$(NuGetPackageVersion)" />
     <PackageReference Include="Microsoft.Azure.Storage.Blob" Version="$(MicrosoftAzureStorageBlobVersion)" />
     <PackageReference Include="Newtonsoft.Json" Version="$(JsonVersion)" Condition=" '$(UseJsonNet901)' != 'true' " />

--- a/src/SleetLib/SleetLib.csproj
+++ b/src/SleetLib/SleetLib.csproj
@@ -31,7 +31,7 @@
 
   <ItemGroup>
     <PackageReference Include="AWSSDK.S3" Version="$(AWSSDKVersion)" />
-    <PackageReference Include="AWSSDK.SecurityToken" Version="$(AWSSDKVersion)" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="3.3.104.74" />
     <PackageReference Include="NuGet.Packaging" Version="$(NuGetPackageVersion)" />
     <PackageReference Include="Microsoft.Azure.Storage.Blob" Version="$(MicrosoftAzureStorageBlobVersion)" />
     <PackageReference Include="Newtonsoft.Json" Version="$(JsonVersion)" Condition=" '$(UseJsonNet901)' != 'true' " />


### PR DESCRIPTION
At the moment the version of the AWS security token package is 10 months out of date and I think that is why my attempt to use [credential_process](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sourcing-external.html) isn't working.

It also seems like it was an oversight to use the variable for the S3 package but not this package.