### PR TITLE
Use non-deprecated method for checking S3 bucket existence

### DIFF
--- a/src/SleetLib/FileSystem/AmazonS3FileSystem.cs
+++ b/src/SleetLib/FileSystem/AmazonS3FileSystem.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Amazon.S3;
 using Amazon.S3.Model;
+using Amazon.S3.Util;
 using Newtonsoft.Json.Linq;
 using NuGet.Common;
 using static Sleet.AmazonS3FileSystemAbstraction;
@@ -101,7 +102,7 @@ namespace Sleet
         {
             if (_hasBucket == null)
             {
-                _hasBucket = await _client.DoesS3BucketExistAsync(_bucketName);
+                _hasBucket = await AmazonS3Util.DoesS3BucketExistV2Async(_client, _bucketName);
             }
 
             return _hasBucket == true;


### PR DESCRIPTION
The deprecated method always uses HTTP rather than HTTPS which wasn't working with our proxy setup, or possibly our S3 bucket policy.