### PR TITLE
DefaultWebProxy support for authenticated proxies

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,5 +1,8 @@
 # Release Notes
 
+## 3.1.20
+* DefaultWebProxy support for authenticated proxies
+
 ## 3.1.0
 * Package retention commands have been added to support pruning feed packages by version. [PR](https://github.com/emgarten/Sleet/pull/110)
 * Fixed bug in specifying S3 feed type through env vars [PR](https://github.com/emgarten/Sleet/pull/108)

--- a/doc/client-settings.md
+++ b/doc/client-settings.md
@@ -191,6 +191,8 @@ Example of defining an azure feed using only environment variables:
 
 To avoid loading up any *sleet.json* files when using env vars pass `--config none` to block it from loading. 
 
+Note that if *sleet.json* is used environment variables will be ignored. It is not possible to mix settings between the two input options.
+
 # Command line properties
 
 Key value pairs can be passed on the command line and are treated the same as environment variables would be.
@@ -205,4 +207,26 @@ In this example a new feed is initialized *without* a sleet.json file. All value
 sleet init --config none -p SLEET_FEED_TYPE=azure -p SLEET_FEED_CONTAINER=feed \
  -p "SLEET_FEED_CONNECTIONSTRING=DefaultEndpointsProtocol=https;AccountName=;AccountKey=;BlobEndpoint="
 ```
+
+# Network proxy settings
+
+Authenticated proxy that use windows credentials should enable the following setting in *sleet.json*
+
+```json
+{
+  "proxy": {
+    "useDefaultCredentials": true
+  },
+  "sources": [
+  ]
+}
+```
+
+This setting can be set through an environment variable or command line property if *sleet.json* is not used.
+
+| Property | Value |
+| --- | ------ |
+| `SLEET_FEED_PROXY_USEDEFAULTCREDENTIALS` | `true` |
+
+
 

--- a/src/Sleet/Util.cs
+++ b/src/Sleet/Util.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Net;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
 using NuGet.Common;
@@ -9,6 +10,15 @@ namespace Sleet
     internal static class Util
     {
         internal static LogLevel DefaultLogLevel = LogLevel.Information;
+
+        internal static void InitNetwork(LocalSettings settings)
+        {
+            var proxySettings = settings?.Json?["proxy"] ?? new JObject();
+            if (proxySettings["useDefaultCredentials"]?.ToObject<bool>() == true)
+            {
+                WebRequest.DefaultWebProxy.Credentials = CredentialCache.DefaultCredentials;
+            }
+        }
 
         internal static async Task<ISleetFileSystem> CreateFileSystemOrThrow(LocalSettings settings, string sourceName, LocalCache cache)
         {
@@ -25,6 +35,10 @@ namespace Sleet
                 }
             }
 
+            // Initialize the network/proxy settings before creating the filesystem
+            InitNetwork(settings);
+
+            // Create
             var fileSystem = await FileSystemFactory.CreateFileSystemAsync(settings, cache, sourceName);
 
             if (fileSystem == null)

--- a/src/SleetLib/Utility/SettingsUtility.cs
+++ b/src/SleetLib/Utility/SettingsUtility.cs
@@ -58,6 +58,10 @@ namespace Sleet
                 sources.Add(source);
                 json["sources"] = sources;
 
+                var proxy = new JObject();
+                json["proxy"] = proxy;
+                proxy["useDefaultCredentials"] = IsTrue(GetTokenValue($"{EnvVarPrefix}PROXY_USEDEFAULTCREDENTIALS", mappings, string.Empty));
+
                 json["username"] = GetTokenValue($"{EnvVarPrefix}USERNAME", mappings, string.Empty);
                 json["useremail"] = GetTokenValue($"{EnvVarPrefix}USEREMAIL", mappings, string.Empty);
 
@@ -117,6 +121,11 @@ namespace Sleet
                     prop.Value = ResolveTokens(prop.Value.ToString(), mappings);
                 }
             }
+        }
+
+        public static bool IsTrue(string value)
+        {
+            return StringComparer.OrdinalIgnoreCase.Equals(bool.TrueString, value);
         }
 
         public static string GetTokenValue(string tokenName, Dictionary<string, string> mappings, string defaultValue)

--- a/test/Sleet.AmazonS3.Tests/BasicTests.cs
+++ b/test/Sleet.AmazonS3.Tests/BasicTests.cs
@@ -185,7 +185,7 @@ namespace Sleet.AmazonS3.Tests
                         testContext.LocalCache, testContext.Uri, baseUri,
                         testContext.Client, testContext.BucketName, ServerSideEncryptionMethod.None
                     );
-                
+
                 testContext.FileSystem = fileSystem;
 
                 await testContext.InitAsync();


### PR DESCRIPTION
Add support for the proxy useDefaultCredentials sleet.json setting.
This gives the equivalent of WebRequest.DefaultWebProxy.Credentials = CredentialCache.DefaultCredentials

Fixes https://github.com/emgarten/Sleet/issues/119