### PR TITLE
Add support for configuring with .netconfig

### DIFF
--- a/build/common/common.ps1
+++ b/build/common/common.ps1
@@ -119,6 +119,7 @@ Function Invoke-DotnetMSBuild {
     $buildArgs += "/nologo"
     $buildArgs += "/v:m"
     $buildArgs += "/nr:false"
+    $buildArgs += "/m:1"
     $buildArgs += $Arguments
 
     Invoke-DotnetExe $RepoRoot $buildArgs

--- a/doc/client-settings.md
+++ b/doc/client-settings.md
@@ -12,6 +12,10 @@ sleet createconfig --azure
 
 The example file contains a set of sources. If only feed exists in the file sleet will automatically use it. Once there two or more sources the ``--source`` parameter will be required to select the correct source.
 
+# .netconfig
+
+Additionally, Sleet supports configuration via [.netconfig](https://dotnetconfig.org) which provides a uniform way of configuring multiple tools with a single file and format. In addition, using `.netconfig` brings support for hierarchical configurations (i.e. reuse source configurations across the entire machine, with a single `.netconfig` in your user profile root directory).
+
 ## Source properties
 
 | Property | Description |
@@ -30,6 +34,7 @@ The example file contains a set of sources. If only feed exists in the file slee
 | path | Full URI of the azure storage container. If specified this value will be verified against the container's URI. |
 | feedSubPath | Provides a sub directory path within the container where the feed should be added. This allows for multiple feeds within a single container. |
 
+`sleet.json`:
 ```json
 {
   "sources": [
@@ -43,6 +48,17 @@ The example file contains a set of sources. If only feed exists in the file slee
   ]
 }
 ```
+
+`.netconfig`:
+
+```gitconfig
+[sleet "feed"]
+    type = azure
+    container = feed
+    connectionString = "DefaultEndpointsProtocol=https;AccountName=;AccountKey=;BlobEndpoint="
+    path = https://yourStorageAccount.blob.core.windows.net/feed/
+```
+
 
 ## Amazon s3 specific properties
 
@@ -63,6 +79,7 @@ Either `region` or `serviceURL` should be specified but not both.
 
 ### Using an AWS credentials file
 
+`sleet.json`:
 ```json
 {
   "sources": [
@@ -78,8 +95,20 @@ Either `region` or `serviceURL` should be specified but not both.
 }
 ```
 
+`.netconfig`:
+
+```gitconfig
+[sleet "feed"]
+    type = s3
+    path = https://s3.amazonaws.com/my-bucket-feed/
+    profileName = sleetProfile
+    bucketName = my-bucket-feed
+    region = us-west-2
+```
+
 ### Using accessKeyId and secretAccessKey in sleet.json
 
+`sleet.json`:
 ```json
 {
   "sources": [
@@ -96,8 +125,20 @@ Either `region` or `serviceURL` should be specified but not both.
 }
 ```
 
+`.netconfig`:
+```gitconfig
+[sleet "feed"]
+    type = s3
+    path = https://s3.amazonaws.com/my-bucket-feed/
+    bucketName = my-bucket-feed
+    region = us-west-2
+    accessKeyId = IAM_ACCESS_KEY_ID
+    secretAccessKey = IAM_SECRET_ACCESS_KEY
+```
+
 ### Using AWS environments
 
+`sleet.json`:
 ```json
 {
   "sources": [
@@ -112,8 +153,18 @@ Either `region` or `serviceURL` should be specified but not both.
 }
 ```
 
+`.netconfig`:
+```gitconfig
+[sleet "feed"]
+    type = s3
+    path = https://s3.amazonaws.com/my-bucket-feed/
+    bucketName = my-bucket-feed
+    region = us-west-2
+```
+
 ### Using serviceURL
 
+`sleet.json`:
 ```json
 {
   "sources": [
@@ -128,6 +179,15 @@ Either `region` or `serviceURL` should be specified but not both.
 }
 ```
 
+`.netconfig`:
+```gitconfig
+[sleet "feed"]
+    type = s3
+    path = https://s3.amazonaws.com/my-bucket-feed/
+    bucketName = my-bucket-feed
+    serviceURL = https://s3.us-east-1.amazonaws.com
+```
+
 
 When running Sleet with [AWS environment variables](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html) leave accessKeyId, secretAccessKey, and profileName blank. If these properties are not set in sleet.json Sleet will try to set up the S3 feed using the environment.
 
@@ -137,6 +197,7 @@ When running Sleet with [AWS environment variables](https://docs.aws.amazon.com/
 | --- | ------ |
 | path | Path is the output directory of the feed. |
 
+`sleet.json`:
 ```json
 {
   "name": "myLocalFeed",
@@ -145,12 +206,20 @@ When running Sleet with [AWS environment variables](https://docs.aws.amazon.com/
 }
 ```
 
-## Tokens in sleet.json
+`.netconfig`:
+```gitconfig
+[sleet "myLocalFeed"]
+    type = local
+    path = C:\\myFeed
+```
 
-Property values in *sleet.json* can be tokenized similar to nuget *.pp* files.
+## Tokens in configuration
+
+Property values in *sleet.json* and *.netconfig* can be tokenized similar to nuget *.pp* files.
 
 Given an environment variable ``myKey`` the following file woudl replace `$myKey$` with the value of the environment variable if it exists.
 
+`sleet.json`:
 ```json
 {
   "sources": [
@@ -164,6 +233,14 @@ Given an environment variable ``myKey`` the following file woudl replace `$myKey
 }
 ```
 
+`.netconfig`:
+```gitconfig
+[sleet "feed"]
+    type = azure
+    container = feed
+    connectionString = "DefaultEndpointsProtocol=https;AccountName=;AccountKey=$myKey$;BlobEndpoint="
+```
+
 Tokens that resolve to a tokenized string will also be resolved, allowing environment variables to point to and combine additional environment variables.
 
 To escape `$` use `$$`.
@@ -173,6 +250,12 @@ To escape `$` use `$$`.
 1. If `--config` was passed the path given will be used.
 1. If no config path was given sleet will search all parent directories starting with the working directory for sleet.json files.
 1. Environment variables will be used if no sleet.json files were found.
+
+## .netconfig loading order
+
+1. If `--config` was passed the path given will be used.
+1. Standard `.netconfig` probing happens next (current directory and all parent directories, plus [global](https://docs.microsoft.com/en-us/dotnet/api/system.environment.specialfolder?view=netstandard-2.0#fields) and [system](https://docs.microsoft.com/en-us/dotnet/api/system.environment.specialfolder?view=netstandard-2.0#fields) locations).
+1. Environment variables will be used if no sleet setting is found.
 
 
 # Environment variables

--- a/doc/feed-type-azure.md
+++ b/doc/feed-type-azure.md
@@ -25,6 +25,15 @@ Edit `sleet.json` using your editor of choice to set the url of your storage acc
 }
 ```
 
+For `.netconfig`, just create or edit the file directly in the [desired location](https://dotnetconfig.org/#what):
+
+```gitconfig
+[sleet "feed"]
+    type = azure
+    container = feed
+    connectionString = "DefaultEndpointsProtocol=https;AccountName=;AccountKey=;BlobEndpoint="
+```
+
 ## Adding packages
 
 Add packages to the feed with the push command, this can be used with either a path to a single nupkg or a folder of nupkgs.

--- a/doc/feed-type-local.md
+++ b/doc/feed-type-local.md
@@ -27,6 +27,20 @@ Open `sleet.json` using your editor of choice, the file will look like similar t
 }
 ```
 
+For `.netconfig`, just create or edit the file directly in the [desired location](https://dotnetconfig.org/#what):
+
+```gitconfig
+[sleet]
+    username = ""
+    useremail = ""
+
+[sleet "myLocalFeed"]
+    type = local
+    container = feed
+    path = C:\\myFeed
+    baseURI = https://example.com/feed/
+```
+
 Set `path` to the local directory on disk where the feed json files will be written.
 
 Change `baseURI` to the URI the http server will use to serve the feed.
@@ -35,16 +49,18 @@ Change `baseURI` to the URI the http server will use to serve the feed.
 
 Now initialize the feed, this creates the basic files needed to get started.
 
-* The `config` value here corresponds to the filesystem path to the `sleet.json` file.
+* The optional `config` value here corresponds to the filesystem path to the `sleet.json` or `.netconfig`
 * the `source` value here corresponds to the `name` property used in `sleet.json`
 
 ``sleet init --config C:\sleet.json --source myLocalFeed``
+
+``sleet init --config C:\.netconfig --source myLocalFeed``
 
 ## Adding packages
 
 Add packages to the feed with the push command, this can be used with either a path to a single nupkg or a folder of nupkgs.
 
-``sleet push --config C:\sleet.json -s myLocalFeed C:\PackagesFolder``
+``sleet push -s myLocalFeed C:\PackagesFolder``
 
 ## Creating the feed's ASP.NET project
 

--- a/doc/feed-type-s3.md
+++ b/doc/feed-type-s3.md
@@ -12,8 +12,11 @@ Edit `sleet.json` using your editor of choice to set the url of your s3 bucket a
 
 ``notepad sleet.json``
 
+For `.netconfig`, just create or edit the file directly in the [desired location](https://dotnetconfig.org/#what).
+
 ### Using an AWS credentials file
 
+`sleet.json`:
 ```json
 {
   "sources": [
@@ -29,10 +32,21 @@ Edit `sleet.json` using your editor of choice to set the url of your s3 bucket a
 }
 ```
 
+`.netconfig`:
+```gitconfig
+[sleet "feed"]
+    type = s3
+    path = https://s3.amazonaws.com/my-bucket-feed/
+    profileName = sleetProfile
+    bucketName = my-bucket-feed
+    region = us-west-2
+```
+
 For details on creating a credentials file go [here](https://docs.aws.amazon.com/sdk-for-net/v2/developer-guide/net-dg-config-creds.html#creds-file)
 
 ### Using accessKeyId and secretAccessKey in sleet.json
 
+`sleet.json`:
 ```json
 {
   "sources": [
@@ -49,10 +63,22 @@ For details on creating a credentials file go [here](https://docs.aws.amazon.com
 }
 ```
 
-This example specifies the access key id and secret key directly in sleet.json.
+`.netconfig`:
+```gitconfig
+[sleet "feed"]
+    type = s3
+    path = https://s3.amazonaws.com/my-bucket-feed/
+    bucketName = my-bucket-feed
+    region = us-east-1
+    accessKeyId = IAM_ACCESS_KEY_ID
+    secretAccessKey = IAM_SECRET_ACCESS_KEY
+```
+
+This example specifies the access key id and secret key directly in sleet.json/.netconfig.
 
 ### Using an EC2 instance profile
 
+`sleet.json`:
 ```json
 {
   "sources": [
@@ -67,10 +93,20 @@ This example specifies the access key id and secret key directly in sleet.json.
 }
 ```
 
+`.netconfig`:
+```gitconfig
+[sleet "feed"]
+    type = s3
+    path = https://s3.amazonaws.com/my-bucket-feed/
+    bucketName = my-bucket-feed
+    region = us-west-2
+```
+
 To use [AWS environment variables](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html) create an s3 feed config without an *accessKeyId* or *secretAccessKey*. Sleet will attempt to automatically configure the feed based on the environment.
 
 ### Using S3 compatible storage
 
+`sleet.json`:
 ```json
 {
   "sources": [
@@ -85,6 +121,17 @@ To use [AWS environment variables](https://docs.aws.amazon.com/cli/latest/usergu
     }
   ]
 }
+```
+
+`.netconfig`:
+```gitconfig
+[sleet "feed"]
+    type = s3
+    path = https://nupkg.website.yandexcloud.net/
+    bucketName = nupkg
+    serviceURL = https://storage.yandexcloud.net
+    accessKeyId = IAM_ACCESS_KEY_ID
+    secretAccessKey = IAM_SECRET_ACCESS_KEY
 ```
 
 To use S3 compatible storage create an s3 feed config with *serviceURL* instead of *region*.

--- a/src/SleetLib/SleetLib.csproj
+++ b/src/SleetLib/SleetLib.csproj
@@ -41,6 +41,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="$(JsonVersion)" Condition=" '$(UseJsonNet901)' != 'true' " />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" Condition=" '$(UseJsonNet901)' == 'true' " />
     <PackageReference Include="Microsoft.DiaSymReader.PortablePdb" Version="$(PortablePdbVersion)" />
+    <PackageReference Include="DotNetConfig" Version="1.0.0-rc" />
   </ItemGroup>
 
   <Import Project="$(BuildCommonDirectory)\common.targets" />

--- a/src/SleetLib/Utility/SettingsUtility.cs
+++ b/src/SleetLib/Utility/SettingsUtility.cs
@@ -70,7 +70,11 @@ namespace Sleet
 
                 // load all env vars with SLEET_FEED_ into the source config
                 // prefer mappings over env vars
-                foreach (var pair in GetSleetEnvVars().Concat(mappings))
+                var entries = GetSleetEnvVars();
+                if (mappings != null)
+                    entries = entries.Concat(mappings);
+
+                foreach (var pair in entries)
                 {
                     if (pair.Key.StartsWith(EnvVarPrefix, StringComparison.OrdinalIgnoreCase))
                     {

--- a/test/Sleet.CmdExe.Tests/DynamicSettingsTests.cs
+++ b/test/Sleet.CmdExe.Tests/DynamicSettingsTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using System.Threading.Tasks;
+using DotNetConfig;
 using FluentAssertions;
 using NuGet.Test.Helpers;
 using Sleet.Test.Common;
@@ -12,6 +13,34 @@ namespace Sleet.CmdExe.Tests
 {
     public class DynamicSettingsTests
     {
+        [WindowsFact]
+        public async Task InitWithEnvVarsWithNonSleetNetConfigVerifyFeedOutput()
+        {
+            using (var testContext = new SleetTestContext())
+            {
+                var dir = Path.Combine(testContext.Root, "sub");
+                var args = $"init -c none";
+
+                Directory.CreateDirectory(dir);
+
+                File.WriteAllText(Path.Combine(dir, Config.FileName), @"
+[config]
+    editor = code
+");
+
+                var envVars = new Dictionary<string, string>()
+                {
+                    { "SLEET_FEED_TYPE", "local" },
+                    { "SLEET_FEED_PATH", dir }
+                };
+
+                var result = await CmdRunner.RunAsync(ExeUtils.SleetExePath, dir, args, envVars);
+
+                result.Success.Should().BeTrue();
+                File.Exists(Path.Combine(dir, "sleet.settings.json")).Should().BeTrue();
+            }
+        }
+
         [WindowsFact]
         public async Task InitWithEnvVarsVerifyFeedOutput()
         {

--- a/test/Sleet.CmdExe.Tests/Sleet.CmdExe.Tests.csproj
+++ b/test/Sleet.CmdExe.Tests/Sleet.CmdExe.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project ToolsVersion="15.0">
+<Project ToolsVersion="15.0">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\build\common\test.props" />
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
 
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="NuGet.Test.Helpers" Version="$(NuGetTestHelpersVersion)" />
+    <PackageReference Include="DotNetConfig" Version="1.0.0-rc" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/SleetLib.Tests/ConfigTests.cs
+++ b/test/SleetLib.Tests/ConfigTests.cs
@@ -1,0 +1,90 @@
+using System;
+using System.IO;
+using System.Linq;
+using DotNetConfig;
+using Newtonsoft.Json.Linq;
+using Sleet;
+using Xunit;
+
+namespace SleetLib.Tests
+{
+    public class ConfigTests
+    {
+        [Fact]
+        public void GivenItCanCanReadDotNetConfigVerifyJsonIsLoaded()
+        {
+            var configFile = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString(), Config.FileName);
+            Directory.CreateDirectory(Path.GetDirectoryName(configFile));
+
+            File.WriteAllText(configFile, @"
+[sleet]
+    feedLockTimeoutMinutes = 30
+    username = foo
+    useremail = foo@bar.com
+    proxy-useDefaultCredentials = true
+
+[sleet ""AzureFeed""]
+    type = azure
+    container = feed
+    connectionString = ""DefaultEndpointsProtocol=https;AccountName=myaccount;AccountKey=;BlobEndpoint=""
+    path = https://myaccount.blob.core.windows.net/feed/
+    feedSubPath = subPath
+
+[sleet ""AmazonFeed""]
+    type = s3
+    bucketName = bucket
+    region = us-east-1
+    profileName = profile
+    path = https://s3.amazonaws.com/my-bucket/
+    feedSubPath = subPath
+    serverSideEncryptionMethod = AES256
+    compress
+
+[sleet ""FolderFeed""]
+    type = local
+    path = C:\\feed
+");
+
+            var settings = LocalSettings.Load(configFile);
+            Assert.NotNull(settings.Json);
+            Assert.Equal(TimeSpan.FromMinutes(30), settings.FeedLockTimeout);
+            Assert.True(settings.Json["proxy"]["useDefaultCredentials"].Value<bool>());
+
+            // envvars are *not* applied because .netconfig contains sleet settings.
+            Assert.Equal("foo", settings.Json["username"].ToString());
+            Assert.Equal("foo@bar.com", settings.Json["useremail"].ToString());
+
+            Assert.Equal(3, settings.Json["sources"].Children().Count());
+
+            Assert.Equal("azure", settings.Json["sources"].First["type"].ToString());
+            Assert.Equal("feed", settings.Json["sources"].First["container"].ToString());
+            Assert.Equal("DefaultEndpointsProtocol=https;AccountName=myaccount;AccountKey=;BlobEndpoint=", settings.Json["sources"].First["connectionString"].ToString());
+            Assert.Equal("https://myaccount.blob.core.windows.net/feed/", settings.Json["sources"].First["path"].ToString());
+            Assert.Equal("subPath", settings.Json["sources"].First["feedSubPath"].ToString());
+
+            Assert.Equal("s3", settings.Json["sources"].Skip(1).First()["type"].ToString());
+            Assert.Equal("bucket", settings.Json["sources"].Skip(1).First()["bucketName"].ToString());
+            Assert.Equal("us-east-1", settings.Json["sources"].Skip(1).First()["region"].ToString());
+            Assert.Equal("https://s3.amazonaws.com/my-bucket/", settings.Json["sources"].Skip(1).First()["path"].ToString());
+            Assert.Equal("subPath", settings.Json["sources"].Skip(1).First()["feedSubPath"].ToString());
+            Assert.Equal("AES256", settings.Json["sources"].Skip(1).First()["serverSideEncryptionMethod"].ToString());
+            Assert.True(settings.Json["sources"].Skip(1).First()["compress"].Value<bool>());
+
+            Assert.Equal("local", settings.Json["sources"].Skip(2).First()["type"].ToString());
+            Assert.Equal("C:\\feed", settings.Json["sources"].Skip(2).First()["path"].ToString());
+        }
+
+        [Fact]
+        public void GivenConfigSpecifiedWithNoSettingsThenThrows()
+        {
+            var file = Path.Combine(Path.GetTempPath(), Config.FileName);
+            File.WriteAllText(file, @"
+[config]
+    editor = code
+");
+
+
+            Assert.Throws<ArgumentException>(() => LocalSettings.Load(file));
+        }
+    }
+}


### PR DESCRIPTION
The [dotnetconfig](https://dotnetconfig.org) format allows hierarchical
tool settings to be persisted and read in a standards way by multiple
tools simultaneously. By adding this support to the tool, all settings
can now also be persisted to the`.netconfig` in the current directory
to streamline subsequent runs. In addition, for scenarios where multiple
projects/repositories in the local machine produce packages that are
pushed to the same feed(s), the `.netconfig` support makes it trivial
to reuse those settings across the entire machine by saving the settings
to the user profile instead.

Updated the docs to cover both `sleet.json` and `.netconfig` formats
equally.