### PR TITLE
Package retention support for release labels

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -5,6 +5,7 @@
 * Dropped netcoreapp2.1 and netcoreapp3.1 support
 * Badges are now enabled by default
 * SVG badges have been removed in favor of using shields.io via json files from the feed
+* Added prune by release labels option to package retention
 
 ## 3.2.1
 * Added badge json for shields.io support [PR](https://github.com/emgarten/Sleet/pull/133)

--- a/doc/commands.md
+++ b/doc/commands.md
@@ -145,6 +145,7 @@ Package retention commands for pruning and limiting package versions.
 | --- | ------ |
 | stable | Number of stable versions per package id to retain. |
 | prerelease | Number of prerelease versions per package id to retain. |
+| release-labels | Retain *prerelease* versions based on the semantic version release labels. |
 | disable | Disable package retention. |
 
 ### Examples
@@ -168,6 +169,44 @@ Or with package ids to prune only select packages
 Disable automatic package pruning with *--disable*
 
 ``sleet retention settings --disable``
+
+### Retain packages by release labels
+
+Sleet supports advanced pruning on prerelease packages using semantic version release labels.
+
+Example feed packages:
+```
+1.0.0-beta.branch.a.build.100
+1.0.0-beta.branch.a.build.101
+1.0.0-beta.branch.a.build.102
+1.0.0-beta.branch.a.build.103
+1.0.0-beta.branch.z.build.205
+1.0.0-beta.branch.z.build.206
+1.0.0-beta.branch.z.build.207
+1.0.0-rc.branch.a.build.308
+```
+
+To prune packages based on the first 3 release labels run:
+
+``sleet retention prune --stable 3 --prerelease 1 --release-labels 3``
+
+Or apply the setting to the feed for future pushes with:
+
+``sleet retention settings --stable 3 --prerelease 1 --release-labels 3``
+
+Packages will be put into unique groups by `VERSION-FIRST.SECOND.THIRD.*` 
+with only the highest `1` prerelease packages remaining.
+
+After the prune the packages left are:
+```
+1.0.0-beta.branch.a.build.102
+1.0.0-beta.branch.z.build.207
+1.0.0-rc.branch.a.build.308
+```
+
+The major, minor, and patch part of the version are used for ordering versions but are not used
+for determining unique groups. All prerelease packages with `beta.branch.a` will be grouped together
+and only the highest version will be left.
 
 ## Properties and settings
 

--- a/src/Sleet/RetentionPruneAppCommand.cs
+++ b/src/Sleet/RetentionPruneAppCommand.cs
@@ -27,6 +27,7 @@ namespace Sleet
 
             var stableVersions = cmd.Option("--stable", "Number of stable versions per package id. If not specified the feed settings will be used.", CommandOptionType.SingleValue);
             var prereleaseVersions = cmd.Option("--prerelease", "Number of prerelease versions per package id. If not specified the feed settings will be used.", CommandOptionType.SingleValue);
+            var releaseLabelsValue = cmd.Option("--release-labels", "Group prerelease packages by the first X release labels. Each group will be pruned to the prerelease max if applied. (optional)", CommandOptionType.SingleValue);
             var packageIds = cmd.Option("--package", "Prune only the given package ids", CommandOptionType.MultipleValue);
             var dryRun = cmd.Option("--dry-run", "Print out all versions that would be deleted without actually removing them.", CommandOptionType.NoValue);
             var propertyOptions = cmd.Option(Constants.PropertyOption, Constants.PropertyDescription, CommandOptionType.MultipleValue);
@@ -55,6 +56,7 @@ namespace Sleet
                         DryRun = dryRun.HasValue(),
                         StableVersionMax = stableVersions.HasValue() ? (int?)int.Parse(stableVersions.Value()) : null,
                         PrereleaseVersionMax = prereleaseVersions.HasValue() ? (int?)int.Parse(prereleaseVersions.Value()) : null,
+                        GroupByFirstPrereleaseLabelCount = releaseLabelsValue.HasValue() ? (int?)int.Parse(releaseLabelsValue.Value()) : null,
                     };
 
                     if (packageIds.HasValue())

--- a/src/Sleet/RetentionSettingsAppCommand.cs
+++ b/src/Sleet/RetentionSettingsAppCommand.cs
@@ -27,6 +27,7 @@ namespace Sleet
 
             var stableVersions = cmd.Option("--stable", "Number of stable versions per package id to retain.", CommandOptionType.SingleValue);
             var prereleaseVersions = cmd.Option("--prerelease", "Number of prerelease versions per package id to retain.", CommandOptionType.SingleValue);
+            var releaseLabelsValue = cmd.Option("--release-labels", "Group prerelease packages by the first X release labels. Each group will be pruned to the prerelease max if applied. (optional)", CommandOptionType.SingleValue);
             var disableRetention = cmd.Option("--disable", "Disable package retention.", CommandOptionType.NoValue);
             var propertyOptions = cmd.Option(Constants.PropertyOption, Constants.PropertyDescription, CommandOptionType.MultipleValue);
 
@@ -58,8 +59,14 @@ namespace Sleet
 
                     var stableVersionMax = stableVersions.HasValue() ? int.Parse(stableVersions.Value()) : -1;
                     var prereleaseVersionMax = prereleaseVersions.HasValue() ? int.Parse(prereleaseVersions.Value()) : -1;
+                    int? releaseLabelsCount = null;
 
-                    success = await RetentionSettingsCommand.RunAsync(settings, fileSystem, stableVersionMax, prereleaseVersionMax, disableRetention.HasValue(), log);
+                    if (releaseLabelsValue.HasValue())
+                    {
+                        releaseLabelsCount = int.Parse(releaseLabelsValue.Value());
+                    }
+
+                    success = await RetentionSettingsCommand.RunAsync(settings, fileSystem, stableVersionMax, prereleaseVersionMax, releaseLabelsCount, disableRetention.HasValue(), log);
 
                     return success ? 0 : 1;
                 }

--- a/src/SleetLib/Commands/RetentionPruneCommand.cs
+++ b/src/SleetLib/Commands/RetentionPruneCommand.cs
@@ -85,6 +85,7 @@ namespace Sleet
 
             var stableMax = pruneContext.StableVersionMax == null ? context.SourceSettings.RetentionMaxStableVersions : pruneContext.StableVersionMax;
             var prerelMax = pruneContext.PrereleaseVersionMax == null ? context.SourceSettings.RetentionMaxPrereleaseVersions : pruneContext.PrereleaseVersionMax;
+            var prerelLabelCount = pruneContext.GroupByFirstPrereleaseLabelCount == null ? context.SourceSettings.RetentionGroupByFirstPrereleaseLabelCount : pruneContext.GroupByFirstPrereleaseLabelCount;
 
             if (stableMax == null || stableMax < 1)
             {
@@ -101,7 +102,7 @@ namespace Sleet
                 allPackages.RemoveWhere(e => !pruneContext.PackageIds.Contains(e.Id));
             }
 
-            var toPrune = RetentionUtility.GetPackagesToPrune(allPackages, pruneContext.PinnedPackages, (int)stableMax, (int)prerelMax);
+            var toPrune = RetentionUtility.GetPackagesToPrune(allPackages, pruneContext.PinnedPackages, (int)stableMax, (int)prerelMax, prerelLabelCount);
 
             await RemovePackages(context, existingPackageSets, toPrune, pruneContext.DryRun, context.Log);
 

--- a/src/SleetLib/Commands/RetentionPruneCommandContext.cs
+++ b/src/SleetLib/Commands/RetentionPruneCommandContext.cs
@@ -13,6 +13,8 @@ namespace Sleet
 
         public int? PrereleaseVersionMax { get; set; }
 
+        public int? GroupByFirstPrereleaseLabelCount { get; set; }
+
         /// <summary>
         /// Filter to only certain package ids.
         /// If empty all packages are processed.

--- a/src/SleetLib/SourceSettings.cs
+++ b/src/SleetLib/SourceSettings.cs
@@ -28,6 +28,13 @@ namespace Sleet
         public int? RetentionMaxPrereleaseVersions { get; set; }
 
         /// <summary>
+        /// Package retention - Number of prelease labels to take when grouping packages.
+        /// Ex: 1.0.0-beta.branch.fox.build.2344 using a count of 3 will allow RetentionMaxPrereleaseVersions
+        /// for all 1.0.0-beta.branch.fox.* packages
+        /// </summary>
+        public int? RetentionGroupByFirstPrereleaseLabelCount { get; set; }
+
+        /// <summary>
         /// Version badges, if enabled svg files for the latest versions will be written out.
         /// </summary>
         public bool BadgesEnabled { get; set; } = false;

--- a/src/SleetLib/Utility/FeedSettingsUtility.cs
+++ b/src/SleetLib/Utility/FeedSettingsUtility.cs
@@ -79,6 +79,9 @@ namespace Sleet
                     case "retentionmaxprereleaseversions":
                         settings.RetentionMaxPrereleaseVersions = GetIntOrDefault(pair.Value, defaultValue: -1);
                         break;
+                    case "retentiongroupbyfirstprereleaselabelcount":
+                        settings.RetentionGroupByFirstPrereleaseLabelCount = GetIntOrDefault(pair.Value, defaultValue: -1);
+                        break;
                 }
             }
 
@@ -116,6 +119,11 @@ namespace Sleet
             if (settings.RetentionMaxPrereleaseVersions > 0)
             {
                 values.Add("retentionmaxprereleaseversions", settings.RetentionMaxPrereleaseVersions.ToString());
+            }
+
+            if (settings.RetentionGroupByFirstPrereleaseLabelCount > 0)
+            {
+                values.Add("retentiongroupbyfirstprereleaselabelcount", settings.RetentionGroupByFirstPrereleaseLabelCount.ToString());
             }
 
             return values;

--- a/src/SleetLib/Utility/RetentionUtility.cs
+++ b/src/SleetLib/Utility/RetentionUtility.cs
@@ -1,8 +1,10 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using NuGet.Packaging.Core;
+using NuGet.Versioning;
 
 namespace Sleet
 {
@@ -22,7 +24,7 @@ namespace Sleet
         /// Find the set of packages to prune for a feed.
         /// Feed package ids that should be checked. Any filtering should happen before this.
         /// </summary>
-        public static HashSet<PackageIdentity> GetPackagesToPrune(HashSet<PackageIdentity> feedPackages, HashSet<PackageIdentity> pinnedPackages, int stableVersionMax, int prereleaseVersionMax)
+        public static HashSet<PackageIdentity> GetPackagesToPrune(HashSet<PackageIdentity> feedPackages, HashSet<PackageIdentity> pinnedPackages, int stableVersionMax, int prereleaseVersionMax, int? groupByUniqueReleaseLabelCount = null)
         {
             var toPrune = new HashSet<PackageIdentity>();
 
@@ -33,7 +35,7 @@ namespace Sleet
 
             var lastId = string.Empty;
             var stable = 0;
-            var pre = 0;
+            var labelLookup = new ConcurrentDictionary<string, int>(StringComparer.OrdinalIgnoreCase);
 
             // Loop through the list of packages
             // When the version count has exceeded the max prune the package
@@ -44,14 +46,19 @@ namespace Sleet
                 if (!StringComparer.OrdinalIgnoreCase.Equals(package.Id, lastId))
                 {
                     stable = 0;
-                    pre = 0;
+                    labelLookup.Clear();
                     lastId = package.Id;
                 }
 
                 var prune = false;
                 if (package.Version.IsPrerelease)
                 {
-                    pre++;
+                    // Split prerelease groups by the given number of release labels
+                    // If the number of labels is 0 then this will always return string.Empty and have
+                    // no impact since all prerelease packages will be in the same group.
+                    var labelKey = GetReleaseLabelKey(package.Version, groupByUniqueReleaseLabelCount);
+                    var pre = labelLookup.AddOrUpdate(labelKey, 1, (k, v) => v + 1);
+
                     prune = pre > prereleaseVersionMax;
                 }
                 else
@@ -68,6 +75,16 @@ namespace Sleet
             }
 
             return toPrune;
+        }
+
+        public static string GetReleaseLabelKey(NuGetVersion version, int? count)
+        {
+            if (count == null || count < 1)
+            {
+                return string.Empty;
+            }
+
+            return string.Join(".", version.ReleaseLabels.Take(count.Value)).ToLowerInvariant();
         }
     }
 }

--- a/test/SleetLib.Tests/FeedSettingsUtilityTests.cs
+++ b/test/SleetLib.Tests/FeedSettingsUtilityTests.cs
@@ -1,9 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.Text;
 using FluentAssertions;
-using Newtonsoft.Json.Linq;
 using Sleet;
 using Xunit;
 

--- a/test/SleetLib.Tests/RetentionUtilityTests.cs
+++ b/test/SleetLib.Tests/RetentionUtilityTests.cs
@@ -219,5 +219,196 @@ namespace SleetLib.Tests
 
             pruned.OrderBy(e => e).Should().BeEquivalentTo(expected.OrderBy(e => e));
         }
+
+        [Fact]
+        public void RetentionUtility_PruneReleaseLabels_TwoLabels_Basic()
+        {
+            var feed = new HashSet<PackageIdentity>()
+            {
+                new PackageIdentity("a", NuGetVersion.Parse("1.0.0-beta.a.1")),
+                new PackageIdentity("a", NuGetVersion.Parse("1.0.0-beta.a.2")),
+                new PackageIdentity("a", NuGetVersion.Parse("1.0.0-beta.a.3")),
+                new PackageIdentity("a", NuGetVersion.Parse("1.0.0-beta.b.1")),
+                new PackageIdentity("a", NuGetVersion.Parse("1.0.0-beta.b.2")),
+                new PackageIdentity("a", NuGetVersion.Parse("1.0.0-beta.b.3")),
+            };
+
+            var pinned = new HashSet<PackageIdentity>();
+
+            var expected = new HashSet<PackageIdentity>()
+            {
+                new PackageIdentity("a", NuGetVersion.Parse("1.0.0-beta.a.1")),
+                new PackageIdentity("a", NuGetVersion.Parse("1.0.0-beta.b.1")),
+            };
+
+            var pruned = RetentionUtility.GetPackagesToPrune(feed, pinned, stableVersionMax: 1024, prereleaseVersionMax: 2, groupByUniqueReleaseLabelCount: 2);
+
+            pruned.OrderBy(e => e).Should().BeEquivalentTo(expected.OrderBy(e => e));
+        }
+
+        [Fact]
+        public void RetentionUtility_PruneReleaseLabels_TwoLabels_MajorVersionDoesNotMatter()
+        {
+            var feed = new HashSet<PackageIdentity>()
+            {
+                new PackageIdentity("a", NuGetVersion.Parse("1.1.1-beta.a.1")),
+                new PackageIdentity("a", NuGetVersion.Parse("2.2.2-beta.a.2")),
+                new PackageIdentity("a", NuGetVersion.Parse("3.3.3-beta.a.3")),
+                new PackageIdentity("a", NuGetVersion.Parse("4.4.4-beta.b.1")),
+                new PackageIdentity("a", NuGetVersion.Parse("5.5.5-beta.b.2")),
+                new PackageIdentity("a", NuGetVersion.Parse("6.6.6-beta.b.3")),
+            };
+
+            var pinned = new HashSet<PackageIdentity>();
+
+            var expected = new HashSet<PackageIdentity>()
+            {
+                new PackageIdentity("a", NuGetVersion.Parse("1.1.1-beta.a.1")),
+                new PackageIdentity("a", NuGetVersion.Parse("4.4.4-beta.b.1")),
+            };
+
+            var pruned = RetentionUtility.GetPackagesToPrune(feed, pinned, stableVersionMax: 1024, prereleaseVersionMax: 2, groupByUniqueReleaseLabelCount: 2);
+
+            pruned.OrderBy(e => e).Should().BeEquivalentTo(expected.OrderBy(e => e));
+        }
+
+        [Fact]
+        public void RetentionUtility_PruneReleaseLabels_TwoLabels_MajorVersionDoesNotMatter_2()
+        {
+            var feed = new HashSet<PackageIdentity>()
+            {
+                new PackageIdentity("a", NuGetVersion.Parse("1.1.1-beta.a.1")),
+                new PackageIdentity("a", NuGetVersion.Parse("2.2.2-beta.a.2")),
+                new PackageIdentity("a", NuGetVersion.Parse("3.3.3-beta.a.3")),
+                new PackageIdentity("a", NuGetVersion.Parse("3.3.3-beta.b.1")),
+                new PackageIdentity("a", NuGetVersion.Parse("1.2.2-beta.b.2")),
+                new PackageIdentity("a", NuGetVersion.Parse("1.1.1-beta.b.3")),
+            };
+
+            var pinned = new HashSet<PackageIdentity>();
+
+            var expected = new HashSet<PackageIdentity>()
+            {
+                new PackageIdentity("a", NuGetVersion.Parse("1.1.1-beta.a.1")),
+                new PackageIdentity("a", NuGetVersion.Parse("1.1.1-beta.b.3")),
+            };
+
+            var pruned = RetentionUtility.GetPackagesToPrune(feed, pinned, stableVersionMax: 1024, prereleaseVersionMax: 2, groupByUniqueReleaseLabelCount: 2);
+
+            pruned.OrderBy(e => e).Should().BeEquivalentTo(expected.OrderBy(e => e));
+        }
+
+        [Fact]
+        public void RetentionUtility_PruneReleaseLabels_TwoLabels()
+        {
+            var feed = new HashSet<PackageIdentity>()
+            {
+                new PackageIdentity("a", NuGetVersion.Parse("1.0.0-beta.a.1")),
+                new PackageIdentity("a", NuGetVersion.Parse("1.0.0-beta.a.2")),
+                new PackageIdentity("a", NuGetVersion.Parse("1.0.0-beta.a.3")),
+                new PackageIdentity("a", NuGetVersion.Parse("1.0.0-beta.A.4")),
+                new PackageIdentity("a", NuGetVersion.Parse("1.0.0-beta.a")),
+                new PackageIdentity("a", NuGetVersion.Parse("1.0.0-beta.b.1")),
+                new PackageIdentity("a", NuGetVersion.Parse("1.0.0-beta.b.2")),
+                new PackageIdentity("a", NuGetVersion.Parse("1.0.0-beta.b.3")),
+                new PackageIdentity("a", NuGetVersion.Parse("1.0.0-beta")),
+                new PackageIdentity("a", NuGetVersion.Parse("1.0.0-beta.5"))
+            };
+
+            var pinned = new HashSet<PackageIdentity>();
+
+            var expected = new HashSet<PackageIdentity>()
+            {
+                new PackageIdentity("a", NuGetVersion.Parse("1.0.0-beta.a.1")),
+                new PackageIdentity("a", NuGetVersion.Parse("1.0.0-beta.a.2")),
+                new PackageIdentity("a", NuGetVersion.Parse("1.0.0-beta.a")),
+                new PackageIdentity("a", NuGetVersion.Parse("1.0.0-beta.b.1")),
+            };
+
+            var pruned = RetentionUtility.GetPackagesToPrune(feed, pinned, stableVersionMax: 1024, prereleaseVersionMax: 2, groupByUniqueReleaseLabelCount: 2);
+
+            pruned.OrderBy(e => e).Should().BeEquivalentTo(expected.OrderBy(e => e));
+        }
+
+        [Fact]
+        public void RetentionUtility_PruneReleaseLabels_TwoLabels_VerifyPerId()
+        {
+            var feed = new HashSet<PackageIdentity>()
+            {
+                new PackageIdentity("b", NuGetVersion.Parse("1.0.0-beta.a.1")),
+                new PackageIdentity("b", NuGetVersion.Parse("1.0.0-beta.a.2")),
+                new PackageIdentity("a", NuGetVersion.Parse("1.0.0-beta.a.1")),
+                new PackageIdentity("a", NuGetVersion.Parse("1.0.0-beta.a.2")),
+                new PackageIdentity("a", NuGetVersion.Parse("1.0.0-beta.a.3")),
+                new PackageIdentity("a", NuGetVersion.Parse("1.0.0-beta.A.4")),
+                new PackageIdentity("a", NuGetVersion.Parse("1.0.0-beta.a")),
+                new PackageIdentity("a", NuGetVersion.Parse("1.0.0-beta.b.1")),
+                new PackageIdentity("a", NuGetVersion.Parse("1.0.0-beta.b.2")),
+                new PackageIdentity("a", NuGetVersion.Parse("1.0.0-beta.b.3")),
+                new PackageIdentity("a", NuGetVersion.Parse("1.0.0-beta")),
+                new PackageIdentity("a", NuGetVersion.Parse("1.0.0-beta.5"))
+            };
+
+            var pinned = new HashSet<PackageIdentity>();
+
+            var expected = new HashSet<PackageIdentity>()
+            {
+                new PackageIdentity("a", NuGetVersion.Parse("1.0.0-beta.a.1")),
+                new PackageIdentity("a", NuGetVersion.Parse("1.0.0-beta.a.2")),
+                new PackageIdentity("a", NuGetVersion.Parse("1.0.0-beta.a")),
+                new PackageIdentity("a", NuGetVersion.Parse("1.0.0-beta.b.1")),
+            };
+
+            var pruned = RetentionUtility.GetPackagesToPrune(feed, pinned, stableVersionMax: 1024, prereleaseVersionMax: 2, groupByUniqueReleaseLabelCount: 2);
+
+            pruned.OrderBy(e => e).Should().BeEquivalentTo(expected.OrderBy(e => e));
+        }
+
+        [Fact]
+        public void RetentionUtility_PruneReleaseLabels_OneLabel()
+        {
+            var feed = new HashSet<PackageIdentity>()
+            {
+                new PackageIdentity("a", NuGetVersion.Parse("1.0.0-beta.a.1")),
+                new PackageIdentity("a", NuGetVersion.Parse("1.0.0-beta.a.2")),
+                new PackageIdentity("a", NuGetVersion.Parse("1.0.0-beta.a.3")),
+                new PackageIdentity("a", NuGetVersion.Parse("1.0.0-beta.a.4")),
+                new PackageIdentity("a", NuGetVersion.Parse("1.0.0-beta.a")),
+                new PackageIdentity("a", NuGetVersion.Parse("1.0.0-beta.b.1")),
+                new PackageIdentity("a", NuGetVersion.Parse("1.0.0-beta.b.2")),
+                new PackageIdentity("a", NuGetVersion.Parse("1.0.0-beta.b.3")),
+                new PackageIdentity("a", NuGetVersion.Parse("1.0.0-beta")),
+                new PackageIdentity("a", NuGetVersion.Parse("1.0.0-beta.5"))
+            };
+
+            var pinned = new HashSet<PackageIdentity>();
+
+            var expected = new HashSet<PackageIdentity>()
+            {
+                new PackageIdentity("a", NuGetVersion.Parse("1.0.0-beta.a.1")),
+                new PackageIdentity("a", NuGetVersion.Parse("1.0.0-beta.a.2")),
+                new PackageIdentity("a", NuGetVersion.Parse("1.0.0-beta.a.3")),
+                new PackageIdentity("a", NuGetVersion.Parse("1.0.0-beta.a.4")),
+                new PackageIdentity("a", NuGetVersion.Parse("1.0.0-beta.a")),
+                new PackageIdentity("a", NuGetVersion.Parse("1.0.0-beta.b.1")),
+                new PackageIdentity("a", NuGetVersion.Parse("1.0.0-beta")),
+                new PackageIdentity("a", NuGetVersion.Parse("1.0.0-beta.5"))
+            };
+
+            var pruned = RetentionUtility.GetPackagesToPrune(feed, pinned, stableVersionMax: 1024, prereleaseVersionMax: 2, groupByUniqueReleaseLabelCount: 1);
+
+            pruned.OrderBy(e => e).Should().BeEquivalentTo(expected.OrderBy(e => e));
+        }
+
+        [Theory]
+        [InlineData("1.0.0-beta.a.1+xyz", 0, "")]
+        [InlineData("1.0.0-beta.a.1+xyz", 1, "beta")]
+        [InlineData("1.0.0-beta.a.1+xyz", 2, "beta.a")]
+        [InlineData("1.0.0-beta.a.1+xyz", -1, "")]
+        [InlineData("1.0.0-beta.a.1+xyz", 5, "beta.a.1")]
+        public void RetentionUtility_GetReleaseLabelKey_NullParts(string version, int count, string expected)
+        {
+            RetentionUtility.GetReleaseLabelKey(NuGetVersion.Parse(version), count).Should().Be(expected);
+        }
     }
 }


### PR DESCRIPTION
* Add feed setting for package retention with release labels
* Add prune option for release labels
* Group packages by their first X release labels when applying pruning

Fixes https://github.com/emgarten/Sleet/issues/129