### PR TITLE
Support external search URIs

### DIFF
--- a/doc/external-search.md
+++ b/doc/external-search.md
@@ -1,0 +1,31 @@
+# External search service
+
+Sleet uses a static search resources by default which returns all packages on the feed. Dynamic search results can be provided through an external service.
+
+## Setting an external search provider
+
+To update a feed set *externalsearch* to the url of the external search provider 
+using the feed settings command.
+
+```
+feed-settings --set "externalsearch:http://example.org/search/query"
+```
+
+The above command will store the external url in *sleet.settings.json* and update
+the service index in the main *index.json* for the feed. NuGet will discover the
+url through the service index and send along the query, prerelease, skip, and take 
+parameters to the new endpoint.
+
+
+## Reverting to static search
+If you no longer wish to use the external search service you can switch back
+by unsetting *externalsearch*
+
+```
+feed-settings --unset "externalsearch"
+```
+
+## Example external search providers
+
+* [Sleet.Search](https://github.com/emgarten/Sleet.Search) - Dockerized azure function that providers filtering for sleet feeds
+

--- a/doc/index.md
+++ b/doc/index.md
@@ -5,6 +5,7 @@
 * [Setting up sources](client-settings.md)
 * [Setting a symbol server](symbol-server.md)
 * [Badges](badges.md)
+* [Setting up an external search endpoint](external-search.md)
 * Quick start guides
   * [Local feed with IIS hosting](feed-type-local.md)
   * [Azure feed](feed-type-azure.md)

--- a/src/SleetLib/Commands/FeedSettingsCommand.cs
+++ b/src/SleetLib/Commands/FeedSettingsCommand.cs
@@ -130,13 +130,15 @@ namespace Sleet
             {
                 var parts = input.Split(new[] { ':' }, StringSplitOptions.RemoveEmptyEntries);
 
-                if (parts.Length != 2 || string.IsNullOrEmpty(parts[0]?.Trim()) || string.IsNullOrEmpty(parts[1]?.Trim()))
+                if (parts.Length < 2 || string.IsNullOrEmpty(parts[0]?.Trim()) || string.IsNullOrEmpty(parts[1]?.Trim()))
                 {
                     throw new ArgumentException("Value must be in the form {key}:{value}. Invalid: '" + input + "'");
                 }
 
                 var key = parts[0].Trim().ToLowerInvariant();
-                var value = parts[1].Trim();
+
+                // Allow : in the value, not the key
+                var value = input.Substring(key.Length + 1);
 
                 if (!setKeysSeen.Add(key))
                 {

--- a/src/SleetLib/Commands/RecreateCommand.cs
+++ b/src/SleetLib/Commands/RecreateCommand.cs
@@ -137,6 +137,8 @@ namespace Sleet
         {
             if (feedSettings.ExternalSearch != null)
             {
+                log.LogMinimal($"Setting external search url: {feedSettings.ExternalSearch}");
+
                 var context = new SleetContext()
                 {
                     LocalSettings = settings,
@@ -148,6 +150,8 @@ namespace Sleet
 
                 var searchHandler = new ExternalSearchHandler(context);
                 await searchHandler.Set(feedSettings.ExternalSearch);
+
+                await source.Commit(log, token);
             }
         }
     }

--- a/src/SleetLib/Commands/RecreateCommand.cs
+++ b/src/SleetLib/Commands/RecreateCommand.cs
@@ -71,6 +71,9 @@ namespace Sleet
                         return false;
                     }
 
+                    // Apply settings
+                    await ApplySettingHandlers(settings, source, log, feedSettings, token);
+
                     // Skip pushing for empty feeds
                     if (Directory.GetFiles(localCache.Root.FullName, "*.*", SearchOption.AllDirectories).Length > 0)
                     {
@@ -125,6 +128,27 @@ namespace Sleet
             }
 
             return success;
+        }
+
+        /// <summary>
+        /// Apply setting handlers
+        /// </summary>
+        private static async Task ApplySettingHandlers(LocalSettings settings, ISleetFileSystem source, ILogger log, FeedSettings feedSettings, CancellationToken token)
+        {
+            if (feedSettings.ExternalSearch != null)
+            {
+                var context = new SleetContext()
+                {
+                    LocalSettings = settings,
+                    SourceSettings = feedSettings,
+                    Log = log,
+                    Source = source,
+                    Token = token
+                };
+
+                var searchHandler = new ExternalSearchHandler(context);
+                await searchHandler.Set(feedSettings.ExternalSearch);
+            }
         }
     }
 }

--- a/src/SleetLib/ExternalSearchHandler.cs
+++ b/src/SleetLib/ExternalSearchHandler.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
+
+namespace Sleet
+{
+    /// <summary>
+    /// Updates search URI in index.json based on externalsearch
+    /// </summary>
+    public class ExternalSearchHandler : IFeedSettingHandler
+    {
+        private readonly SleetContext _context;
+        private readonly Search _search;
+
+        public string Name => "externalsearch";
+
+        public ExternalSearchHandler(SleetContext context)
+        {
+            _context = context ?? throw new ArgumentNullException(nameof(context));
+            _search = new Search(context);
+        }
+
+        public Task Set(string value)
+        {
+            // Apply user set search uri
+            return SetSearchUri(value);
+        }
+
+        public Task UnSet()
+        {
+            // Revert to default uri
+            var feedSearchUri = _search.RootIndexFile.EntityUri.AbsoluteUri;
+            return SetSearchUri(feedSearchUri);
+        }
+
+        private async Task SetSearchUri(string value)
+        {
+            var indexFile = _context.Source.Get("index.json");
+            var json = await indexFile.GetJson(_context.Log, _context.Token);
+            var searchEntry = GetSearchEntry(json);
+            searchEntry["@id"] = value;
+            await indexFile.Write(json, _context.Log, _context.Token);
+        }
+
+        private JObject GetSearchEntry(JObject serviceIndex)
+        {
+            var resources = (JArray)serviceIndex["resources"];
+            return (JObject)resources.First(e => e["@type"].ToObject<string>().StartsWith("SearchQueryService/"));
+        }
+    }
+}

--- a/src/SleetLib/SourceSettings.cs
+++ b/src/SleetLib/SourceSettings.cs
@@ -38,5 +38,10 @@ namespace Sleet
         /// Version badges, if enabled svg files for the latest versions will be written out.
         /// </summary>
         public bool BadgesEnabled { get; set; } = false;
+
+        /// <summary>
+        /// External search URI
+        /// </summary>
+        public string ExternalSearch { get; set; } = null;
     }
 }

--- a/src/SleetLib/Utility/FeedSettingsUtility.cs
+++ b/src/SleetLib/Utility/FeedSettingsUtility.cs
@@ -82,6 +82,9 @@ namespace Sleet
                     case "retentiongroupbyfirstprereleaselabelcount":
                         settings.RetentionGroupByFirstPrereleaseLabelCount = GetIntOrDefault(pair.Value, defaultValue: -1);
                         break;
+                    case "externalsearch":
+                        settings.ExternalSearch = GetStringOrDefault(pair.Value, null);
+                        break;
                 }
             }
 
@@ -126,6 +129,11 @@ namespace Sleet
                 values.Add("retentiongroupbyfirstprereleaselabelcount", settings.RetentionGroupByFirstPrereleaseLabelCount.ToString());
             }
 
+            if (!string.IsNullOrWhiteSpace(settings.ExternalSearch))
+            {
+                values.Add("externalsearch", settings.ExternalSearch);
+            }
+
             return values;
         }
 
@@ -147,6 +155,16 @@ namespace Sleet
             if (int.TryParse(s, out var result))
             {
                 return result;
+            }
+
+            return defaultValue;
+        }
+
+        private static string GetStringOrDefault(string s, string defaultValue)
+        {
+            if (!string.IsNullOrWhiteSpace(s))
+            {
+                return s;
             }
 
             return defaultValue;
@@ -220,6 +238,16 @@ namespace Sleet
             json["value"] = setting.Value;
 
             return json;
+        }
+
+        public static Dictionary<string, IFeedSettingHandler> GetSettingHandlers(SleetContext context)
+        {
+            var search = new ExternalSearchHandler(context);
+
+            return new Dictionary<string, IFeedSettingHandler>()
+            {
+                { search.Name, search }
+            };
         }
     }
 }

--- a/src/SleetLib/def/IFeedSettingHandler.cs
+++ b/src/SleetLib/def/IFeedSettingHandler.cs
@@ -1,0 +1,27 @@
+using System.Threading.Tasks;
+
+namespace Sleet
+{
+    /// <summary>
+    /// Apply additional operations when a feed setting is applied.
+    /// The setting is managed in sleet.settings.json outside of this
+    /// handler. Handlers are only used for advanced settings.
+    /// </summary>
+    public interface IFeedSettingHandler
+    {
+        /// <summary>
+        /// Name in sleet.settings.json
+        /// </summary>
+        string Name { get; }
+
+        /// <summary>
+        /// Called when the setting it set by the user.
+        /// </summary>
+        Task Set(string value);
+
+        /// <summary>
+        /// Called when the setting is cleared by the user.
+        /// </summary>
+        Task UnSet();
+    }
+}

--- a/test/SleetLib.Tests/ExternalSearchTests.cs
+++ b/test/SleetLib.Tests/ExternalSearchTests.cs
@@ -1,0 +1,234 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Newtonsoft.Json.Linq;
+using NuGet.Test.Helpers;
+using Sleet;
+using Xunit;
+
+namespace SleetLib.Tests
+{
+    public class ExternalSearchTests
+    {
+        [Fact]
+        public async Task VerifySetUpdatesIndexJson()
+        {
+            using (var packagesFolder = new TestFolder())
+            using (var target = new TestFolder())
+            using (var cache = new LocalCache())
+            using (var outputFolder = new TestFolder())
+            {
+                var log = new TestLogger();
+                var fileSystem = new PhysicalFileSystem(cache, UriUtility.CreateUri(target.Root));
+                var settings = new LocalSettings();
+
+                var context = new SleetContext()
+                {
+                    Token = CancellationToken.None,
+                    LocalSettings = settings,
+                    Log = log,
+                    Source = fileSystem,
+                    SourceSettings = new FeedSettings()
+                };
+
+                var success = await InitCommand.RunAsync(settings, fileSystem, log);
+
+                success &= await FeedSettingsCommand.RunAsync(
+                    settings,
+                    fileSystem,
+                    unsetAll: false,
+                    getAll: false,
+                    getSettings: Array.Empty<string>(),
+                    unsetSettings: Array.Empty<string>(),
+                    setSettings: new string[] { "externalsearch:https://example.org/search/query" },
+                    log: log,
+                    token: context.Token);
+
+                success.Should().BeTrue();
+
+                var indexJsonPath = Path.Combine(target.RootDirectory.FullName, "index.json");
+                var entry = GetSearchEntry(indexJsonPath);
+                var value = entry["@id"].ToObject<string>();
+
+                value.Should().Be("https://example.org/search/query");
+            }
+        }
+
+        [Fact]
+        public async Task VerifyUnSetUpdatesIndexJson()
+        {
+            using (var packagesFolder = new TestFolder())
+            using (var target = new TestFolder())
+            using (var cache = new LocalCache())
+            using (var outputFolder = new TestFolder())
+            {
+                var log = new TestLogger();
+                var fileSystem = new PhysicalFileSystem(cache, UriUtility.CreateUri(target.Root));
+                var settings = new LocalSettings();
+
+                var context = new SleetContext()
+                {
+                    Token = CancellationToken.None,
+                    LocalSettings = settings,
+                    Log = log,
+                    Source = fileSystem,
+                    SourceSettings = new FeedSettings()
+                };
+
+                var success = await InitCommand.RunAsync(settings, fileSystem, log);
+
+                success &= await FeedSettingsCommand.RunAsync(
+                    settings,
+                    fileSystem,
+                    unsetAll: false,
+                    getAll: false,
+                    getSettings: Array.Empty<string>(),
+                    unsetSettings: Array.Empty<string>(),
+                    setSettings: new string[] { "externalsearch:https://example.org/search/query" },
+                    log: log,
+                    token: context.Token);
+
+                success &= await FeedSettingsCommand.RunAsync(
+                    settings,
+                    fileSystem,
+                    unsetAll: false,
+                    getAll: false,
+                    getSettings: Array.Empty<string>(),
+                    unsetSettings: new string[] { "externalsearch" },
+                    setSettings: Array.Empty<string>(),
+                    log: log,
+                    token: context.Token);
+
+                success.Should().BeTrue();
+
+                var indexJsonPath = Path.Combine(target.RootDirectory.FullName, "index.json");
+                var entry = GetSearchEntry(indexJsonPath);
+                var value = entry["@id"].ToObject<string>();
+
+                value.Should().NotBe("https://example.org/search/query");
+            }
+        }
+
+        [Fact]
+        public async Task VerifyUnSetAllUpdatesIndexJson()
+        {
+            using (var packagesFolder = new TestFolder())
+            using (var target = new TestFolder())
+            using (var cache = new LocalCache())
+            using (var outputFolder = new TestFolder())
+            {
+                var log = new TestLogger();
+                var fileSystem = new PhysicalFileSystem(cache, UriUtility.CreateUri(target.Root));
+                var settings = new LocalSettings();
+
+                var context = new SleetContext()
+                {
+                    Token = CancellationToken.None,
+                    LocalSettings = settings,
+                    Log = log,
+                    Source = fileSystem,
+                    SourceSettings = new FeedSettings()
+                };
+
+                var success = await InitCommand.RunAsync(settings, fileSystem, log);
+
+                success &= await FeedSettingsCommand.RunAsync(
+                    settings,
+                    fileSystem,
+                    unsetAll: false,
+                    getAll: false,
+                    getSettings: Array.Empty<string>(),
+                    unsetSettings: Array.Empty<string>(),
+                    setSettings: new string[] { "externalsearch:https://example.org/search/query" },
+                    log: log,
+                    token: context.Token);
+
+                success &= await FeedSettingsCommand.RunAsync(
+                    settings,
+                    fileSystem,
+                    unsetAll: true,
+                    getAll: false,
+                    getSettings: Array.Empty<string>(),
+                    unsetSettings: Array.Empty<string>(),
+                    setSettings: Array.Empty<string>(),
+                    log: log,
+                    token: context.Token);
+
+                success.Should().BeTrue();
+
+                var indexJsonPath = Path.Combine(target.RootDirectory.FullName, "index.json");
+                var entry = GetSearchEntry(indexJsonPath);
+                var value = entry["@id"].ToObject<string>();
+
+                value.Should().NotBe("https://example.org/search/query");
+            }
+        }
+
+        [Fact]
+        public async Task VerifyRecreateKeepsExternalSearch()
+        {
+            using (var tmpFolder = new TestFolder())
+            using (var packagesFolder = new TestFolder())
+            using (var target = new TestFolder())
+            using (var cache = new LocalCache())
+            using (var outputFolder = new TestFolder())
+            {
+                var log = new TestLogger();
+                var fileSystem = new PhysicalFileSystem(cache, UriUtility.CreateUri(target.Root));
+                var settings = new LocalSettings();
+
+                var context = new SleetContext()
+                {
+                    Token = CancellationToken.None,
+                    LocalSettings = settings,
+                    Log = log,
+                    Source = fileSystem,
+                    SourceSettings = new FeedSettings()
+                };
+
+                var success = await InitCommand.RunAsync(settings, fileSystem, log);
+
+                success &= await FeedSettingsCommand.RunAsync(
+                    settings,
+                    fileSystem,
+                    unsetAll: false,
+                    getAll: false,
+                    getSettings: Array.Empty<string>(),
+                    unsetSettings: Array.Empty<string>(),
+                    setSettings: new string[] { "externalsearch:https://example.org/search/query" },
+                    log: log,
+                    token: context.Token);
+
+                success &= await RecreateCommand.RunAsync(
+                    settings,
+                    fileSystem,
+                    tmpFolder.RootDirectory.FullName,
+                    false,
+                    context.Log);
+
+                success.Should().BeTrue();
+
+                var indexJsonPath = Path.Combine(target.RootDirectory.FullName, "index.json");
+                var entry = GetSearchEntry(indexJsonPath);
+                var value = entry["@id"].ToObject<string>();
+
+                value.Should().Be("https://example.org/search/query");
+            }
+        }
+
+        private JObject GetSearchEntry(string indexJsonPath)
+        {
+            var json = JObject.Parse(File.ReadAllText(indexJsonPath));
+            return GetSearchEntry(json);
+        }
+
+        private JObject GetSearchEntry(JObject serviceIndex)
+        {
+            var resources = (JArray)serviceIndex["resources"];
+            return (JObject)resources.First(e => e["@type"].ToObject<string>().StartsWith("SearchQueryService/"));
+        }
+    }
+}


### PR DESCRIPTION
* Add `externalsearch` feed setting
* Add `IFeedSettingHandler` to support additional feed changes when a setting is updated
* `ExternalSearchHandler` will update the search URI in `index.json` when `externalsearch` is set or unset

Fixes https://github.com/emgarten/Sleet/issues/79