### PR TITLE
Sleet exe standalone publish

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ os:
 osx_image: xcode7.1
 branches:
   only:
-    - master
+    - main
 script:
   - ./build.sh
 addons:

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## 4.1.0
+* Sleet.exe is now produced by dotnet publish as a standalone file instead of by ILMerge
+* Removed net472 support from SleetLib
+
 ## 4.0.0
 * Added net5.0 support
 * Dropped netcoreapp2.1 and netcoreapp3.1 support

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,7 @@ init:
   - git config --global core.autocrlf input
 branches:
   only:
-    - master
+    - main
 build_script:
   - build.cmd
 clone_depth: 1

--- a/build.ps1
+++ b/build.ps1
@@ -56,6 +56,9 @@ Invoke-DotnetFormat $RepoRoot
 Remove-Artifacts $RepoRoot
 Invoke-DotnetMSBuild $RepoRoot ("build\build.proj", "/t:Clean;WriteGitInfo", "/p:Configuration=$Configuration")
 
+# Build Exe
+Invoke-DotnetExe $RepoRoot ("publish", "-r", "win-x64", "-p:PublishSingleFile=true", "--self-contained", "true", "-f", "net5.0", "-o", (Join-Path $RepoRoot "artifacts\publish"), (Join-Path $RepoRoot "\src\Sleet\Sleet.csproj"))
+
 # Restore
 Invoke-DotnetMSBuild $RepoRoot ("build\build.proj", "/t:Restore", "/p:Configuration=$Configuration")
 

--- a/build.ps1
+++ b/build.ps1
@@ -57,7 +57,7 @@ Remove-Artifacts $RepoRoot
 Invoke-DotnetMSBuild $RepoRoot ("build\build.proj", "/t:Clean;WriteGitInfo", "/p:Configuration=$Configuration")
 
 # Build Exe
-Invoke-DotnetExe $RepoRoot ("publish", "-r", "win-x64", "-p:PublishSingleFile=true", "--self-contained", "true", "-f", "net5.0", "-o", (Join-Path $RepoRoot "artifacts\publish"), (Join-Path $RepoRoot "\src\Sleet\Sleet.csproj"))
+Invoke-DotnetExe $RepoRoot ("publish", "--force", "-r", "win-x64", "-p:PublishSingleFile=true", "--self-contained", "true", "-f", "net5.0", "-o", (Join-Path $RepoRoot "artifacts\publish"), (Join-Path $RepoRoot "\src\Sleet\Sleet.csproj"))
 
 # Restore
 Invoke-DotnetMSBuild $RepoRoot ("build\build.proj", "/t:Restore", "/p:Configuration=$Configuration")

--- a/build/build.proj
+++ b/build/build.proj
@@ -14,31 +14,13 @@
           DependsOnTargets="Build;Publish"
           BeforeTargets="Pack">
 
-    <PropertyGroup>
-      <MergeFile>Sleet.exe</MergeFile>
-      <ILRepackExePath>$(PackagesConfigDirectory)ILRepack.2.0.12\tools\ILRepack.exe</ILRepackExePath>
-      <MergeDirectory>$(PublishOutputDirectory)net472\</MergeDirectory>
-      <MergeMainAssembly>$(MergeDirectory)$(MergeFile)</MergeMainAssembly>
-      <MergeOutputPath>$(PublishOutputDirectory)$(MergeFile)</MergeOutputPath>
-      <MergeJsonNetDir>$(PackagesConfigDirectory)Newtonsoft.Json.6.0.8\lib\net45</MergeJsonNetDir>
-      <MergeLogPath>$(LogOutputDirectory)mergelog.txt</MergeLogPath>
-      <MergeMainExists Condition="Exists($(MergeMainAssembly))">true</MergeMainExists>
-    </PropertyGroup>
-
     <!-- Build command -->
     <PropertyGroup>
-      <MergeExeCommand>$(ILRepackExePath) $(MergeMainAssembly) $(MergeDirectory)*.dll /lib:$(MergeDirectory) /lib:$(MergeJsonNetDir) /out:$(MergeOutputPath) /log:$(MergeLogPath) /parallel /wildcards /internalize</MergeExeCommand>
-      <MergeExeCommand Condition=" '$(SignKeyPath)' != '' ">$(MergeExeCommand) /keyfile:$(SignKeyPath)</MergeExeCommand>
+      <PublishSleetExeCommand>$(DotnetExePath) publish -r win-x64 -p:PublishSingleFile=true --self-contained true -f net5.0 -o $(PublishOutputDirectory)  $(RepositoryRootDirectory)\src\Sleet\Sleet.csproj</PublishSleetExeCommand>
     </PropertyGroup>
-
-    <!-- Verify files exist -->
-    <Error Condition=" '$(MergeMainExists)' != 'true' " Text="$(MergeMainAssembly) does not exist! Build first!" />
-
-    <!-- Create output directories -->
-    <MakeDir Directories="$(PublishOutputDirectory);$(LogOutputDirectory)" />
     
     <!-- Run command -->
-    <Exec Command="$(MergeExeCommand)" ContinueOnError="false" StandardOutputImportance="low" />
+    <Exec Command="$(PublishSleetExeCommand)" ContinueOnError="false" StandardOutputImportance="low" />
   </Target>
 
   <!--

--- a/build/build.proj
+++ b/build/build.proj
@@ -4,40 +4,4 @@
   
   <!-- Add custom targets and overrides here -->
 
-  <!--
-    ============================================================
-    ILRepack assemblies for the tool exe
-    ============================================================
-  -->
-  <Target Name="PublishArtifacts"
-          Condition=" '$(SkipPublishArtifacts)' != 'true' AND '$(IsXPlat)' != 'true' "
-          DependsOnTargets="Build;Publish"
-          BeforeTargets="Pack">
-
-    <!-- Build command -->
-    <PropertyGroup>
-      <PublishSleetExeCommand>$(DotnetExePath) publish -r win-x64 -p:PublishSingleFile=true --self-contained true -f net5.0 -o $(PublishOutputDirectory)  $(RepositoryRootDirectory)\src\Sleet\Sleet.csproj</PublishSleetExeCommand>
-    </PropertyGroup>
-    
-    <!-- Run command -->
-    <Exec Command="$(PublishSleetExeCommand)" ContinueOnError="false" StandardOutputImportance="low" />
-  </Target>
-
-  <!--
-    ============================================================
-    Remove desktop dependencies from Sleet package.
-    ============================================================
-  -->
-  <Target Name="RemoveDesktopDependencies"
-        Condition=" '$(SkipPublishArtifacts)' != 'true' AND '$(IsXPlat)' != 'true' "
-        AfterTargets="Pack">
-
-    <PropertyGroup>
-      <NupkgWrenchExePath>$(PackagesConfigDirectory)NupkgWrenchExe.1.4.25\tools\NupkgWrench.exe</NupkgWrenchExePath>
-      <WrenchExeCommand>$(NupkgWrenchExePath) nuspec dependencies remove --id Sleet $(NupkgOutputDirectory)</WrenchExeCommand>
-    </PropertyGroup>
-
-    <Exec Command="$(WrenchExeCommand)" ContinueOnError="false" StandardOutputImportance="low" />
-  </Target>
-
 </Project>

--- a/build/common/common.ps1
+++ b/build/common/common.ps1
@@ -134,7 +134,7 @@ Function Install-DotnetTools {
 
     if (-not (Test-Path $toolsPath)) {
         Write-Host "Installing dotnet tools to $toolsPath"
-        $args = @("tool","install","--tool-path",$toolsPath,"--ignore-failed-sources","dotnet-format","--version","4.1.131201 ")
+        $args = @("tool","install","--tool-path",$toolsPath,"--ignore-failed-sources","dotnet-format","--version","5.0.211103")
 
         Invoke-DotnetExe $RepoRoot $args
     }
@@ -157,7 +157,7 @@ Function Invoke-DotnetFormat {
 
     $formatExe = Join-Path $RepoRoot ".nuget/tools/dotnet-format.exe"
 
-    $args = @("-w",$RepoRoot)
+    $args = @("--fix-whitespace","--fix-style", "warn", "--fix-analyzers", "warn")
 
     # On CI builds run a check instead of making code changes
     if ($env:CI -eq "True") 

--- a/build/common/common.sh
+++ b/build/common/common.sh
@@ -28,10 +28,10 @@ run_standard_tests()
     echo "Installing dotnet tools"
     mkdir -p .nuget/tools
     
-    $DOTNET tool install --tool-path $DOTNET_TOOLS --ignore-failed-sources dotnet-format --version 4.1.131201
+    $DOTNET tool install --tool-path $DOTNET_TOOLS --ignore-failed-sources dotnet-format --version 5.0.211103
   fi
 
-  $DOTNET_FORMAT -w $REPO_ROOT
+  $DOTNET_FORMAT --fix-whitespace --fix-style warn --fix-analyzers warn
 
   # clean
   rm -r -f $(pwd)/artifacts

--- a/src/Sleet/Sleet.csproj
+++ b/src/Sleet/Sleet.csproj
@@ -2,10 +2,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\build\common\common.props" />
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
 
-  <PropertyGroup Condition=" '$(IsXPlat)' != 'true' ">
-    <TargetFrameworks>net5.0;net472</TargetFrameworks>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(IsXPlat)' == 'true' OR '$(PackSleetDotnetTool)' == 'true' ">
+  <PropertyGroup>
     <TargetFrameworks>net5.0</TargetFrameworks>
   </PropertyGroup>
 
@@ -24,6 +21,16 @@
     <SkipDocs>true</SkipDocs>
 
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
+  </PropertyGroup>
+
+  <!-- Sleet.exe settings -->
+  <PropertyGroup Condition=" '$(PublishSingleFile)' == 'true' ">
+    <PublishSingleFile>true</PublishSingleFile>
+    <SelfContained>true</SelfContained>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <PublishTrimmed>true</PublishTrimmed>
+    <PublishReadyToRun>true</PublishReadyToRun>
+    <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Sleet/Sleet.csproj
+++ b/src/Sleet/Sleet.csproj
@@ -69,7 +69,7 @@
     <!-- Pack Sleet -->
     <MSBuild Projects="$(MSBuildProjectFullPath)" Targets="Pack" Properties="Configuration=$(Configuration);PackageOutputPath=$(NupkgOutputDirectory);PackSleetDotnetTool=true" />
     <!-- Pack Sleet Exe -->
-    <MSBuild Projects="$(MSBuildProjectFullPath)" Targets="Pack" Condition=" '$(MergedExePathExists)' == 'true' " Properties="Configuration=$(Configuration);PackageOutputPath=$(NupkgOutputDirectory);NoPackageAnalysis=true;IncludeSymbols=false;NuspecFile=SleetExe.nuspec;NuspecProperties=$(NuspecProperties);" />
+    <MSBuild Projects="$(MSBuildProjectFullPath)" Targets="Pack"  Properties="Configuration=$(Configuration);PackageOutputPath=$(NupkgOutputDirectory);NoPackageAnalysis=true;IncludeSymbols=false;NuspecFile=$(MSBuildProjectDirectory)\SleetExe.nuspec;NuspecProperties=$(NuspecProperties);PackageId=SleetExe" />
   </Target>
 
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />

--- a/src/SleetLib/SleetLib.csproj
+++ b/src/SleetLib/SleetLib.csproj
@@ -1,10 +1,7 @@
 <Project ToolsVersion="15.0">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\build\common\common.props" />
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
-  <PropertyGroup Condition=" '$(IsXPlat)' != 'true' ">
-    <TargetFrameworks>netstandard2.0;net472</TargetFrameworks>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(IsXPlat)' == 'true' ">
+  <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 
@@ -23,10 +20,6 @@
 
   <ItemGroup>
     <EmbeddedResource Include="compiler\resources\**\*" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
-    <Reference Include="System.IO.Compression" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Sleet.Integration.Tests/Sleet.Integration.Tests.csproj
+++ b/test/Sleet.Integration.Tests/Sleet.Integration.Tests.csproj
@@ -2,17 +2,9 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\build\common\test.props" />
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
 
-  <PropertyGroup Condition=" '$(IsXPlat)' != 'true' ">
-    <TargetFrameworks>net5.0;net472</TargetFrameworks>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(IsXPlat)' == 'true' ">
+  <PropertyGroup>
     <TargetFrameworks>net5.0</TargetFrameworks>
   </PropertyGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
-    <Reference Include="System.IO.Compression" />
-    <Reference Include="System.Net.Http" />
-  </ItemGroup>
   
   <PropertyGroup>
     <TestProject>true</TestProject>

--- a/test/Sleet.Test.Common/Sleet.Test.Common.csproj
+++ b/test/Sleet.Test.Common/Sleet.Test.Common.csproj
@@ -1,10 +1,7 @@
 ﻿<Project ToolsVersion="15.0">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\build\common\common.props" />
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
-  <PropertyGroup Condition=" '$(IsXPlat)' != 'true' ">
-    <TargetFrameworks>netstandard2.0;net472</TargetFrameworks>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(IsXPlat)' == 'true' ">
+  <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 
@@ -15,10 +12,6 @@
   <ItemGroup>
     <PackageReference Include="NuGet.Test.Helpers" Version="$(NuGetTestHelpersVersion)" />
     <PackageReference Include="Xunit" Version="$(XunitVersion)" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
-    <Reference Include="System.IO.Compression" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' != 'net472' ">

--- a/test/SleetLib.Tests/SleetLib.Tests.csproj
+++ b/test/SleetLib.Tests/SleetLib.Tests.csproj
@@ -2,18 +2,10 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\build\common\test.props" />
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
 
-  <PropertyGroup Condition=" '$(IsXPlat)' != 'true' ">
-    <TargetFrameworks>net5.0;net472</TargetFrameworks>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(IsXPlat)' == 'true' ">
+  <PropertyGroup>
     <TargetFrameworks>net5.0</TargetFrameworks>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
-    <Reference Include="System.IO.Compression" />
-    <Reference Include="System.Net.Http" />
-  </ItemGroup>
-  
   <PropertyGroup>
     <TestProject>true</TestProject>
   </PropertyGroup>


### PR DESCRIPTION
* Update dotnet format
* Publish Sleet.exe as a standalone file instead of using ILMerge
* Remove net472 support in favor of netstandard2.0