### PR TITLE
Fix formatter errors

### DIFF
--- a/build/common/common.ps1
+++ b/build/common/common.ps1
@@ -155,25 +155,23 @@ Function Invoke-DotnetFormat {
         [string]$RepoRoot
     )
 
-    $formatExe = Join-Path $RepoRoot ".nuget/tools/dotnet-format.exe"
-
-    $args = @("--fix-whitespace","--fix-style", "warn")
-
-    # On CI builds run a check instead of making code changes
-    if ($env:CI -eq "True") 
+    # Only run in local dev envs
+    if ($env:CI -ne "True") 
     {
-        $args += "--check"
-    }
+        $formatExe = Join-Path $RepoRoot ".nuget/tools/dotnet-format.exe"
 
-    $command = "$formatExe $args"
-    Write-Host "[EXEC] $command" -ForegroundColor Cyan
+        $args = @("--fix-whitespace", "--fix-style", "warn")
 
-    & $formatExe $args
+        $command = "$formatExe $args"
+        Write-Host "[EXEC] $command" -ForegroundColor Cyan
 
-    if (-not $?) {
-        Write-Warning "dotnet-format failed. Please fix the style errors!"
+        & $formatExe $args
 
-        # Currently dotnet-format fails on CIs but not locally in some scenarios
-        # exit 1
+        if (-not $?) {
+            Write-Warning "dotnet-format failed. Please fix the style errors!"
+
+            # Currently dotnet-format fails on CIs but not locally in some scenarios
+            # exit 1
+        }
     }
 }

--- a/build/config.props
+++ b/build/config.props
@@ -10,6 +10,7 @@
     <PortablePdbVersion>1.5.0</PortablePdbVersion>
     <AWSSDKVersion>3.7.4.9</AWSSDKVersion>
     <AWSSDKTokenVersion>3.7.1.92</AWSSDKTokenVersion>
+    <DotNetConfigVersion>1.0.6</DotNetConfigVersion>
   </PropertyGroup>
 
   <!-- Config -->

--- a/src/SleetLib/SleetLib.csproj
+++ b/src/SleetLib/SleetLib.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="Microsoft.Azure.Storage.Blob" Version="$(MicrosoftAzureStorageBlobVersion)" />
     <PackageReference Include="Newtonsoft.Json" Version="$(JsonVersion)" />
     <PackageReference Include="Microsoft.DiaSymReader.PortablePdb" Version="$(PortablePdbVersion)" />
-    <PackageReference Include="DotNetConfig" Version="1.0.0-rc" />
+    <PackageReference Include="DotNetConfig" Version="$(DotNetConfigVersion)" />
   </ItemGroup>
 
   <Import Project="$(BuildCommonDirectory)\common.targets" />

--- a/test/Sleet.CmdExe.Tests/Sleet.CmdExe.Tests.csproj
+++ b/test/Sleet.CmdExe.Tests/Sleet.CmdExe.Tests.csproj
@@ -12,7 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="NuGet.Test.Helpers" Version="$(NuGetTestHelpersVersion)" />
-    <PackageReference Include="DotNetConfig" Version="1.0.0-rc" />
+    <PackageReference Include="DotNetConfig" Version="$(DotNetConfigVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Sleet.Test.Common/Sleet.Test.Common.csproj
+++ b/test/Sleet.Test.Common/Sleet.Test.Common.csproj
@@ -14,10 +14,6 @@
     <PackageReference Include="Xunit" Version="$(XunitVersion)" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' != 'net472' ">
-    <PackageReference Include="System.IO.FileSystem" Version="4.3.0" />
-  </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\src\SleetLib\SleetLib.csproj" />
   </ItemGroup>


### PR DESCRIPTION
dotnet format fails on the CI over project metadata issues. It isn't clear what is causing this and the formatter does not need to run on the CI so it will now be skipped in CI scenarios.