### PR TITLE
Ignore the 404 error when deleting the bucket to make it more resilie…

### DIFF
--- a/src/SleetLib/FileSystem/AmazonS3FileSystem.cs
+++ b/src/SleetLib/FileSystem/AmazonS3FileSystem.cs
@@ -193,7 +193,15 @@ namespace Sleet
         {
             if (await HasBucket(log, token))
             {
-                await _client.DeleteBucketAsync(_bucketName, token);
+                try 
+                {
+                    await _client.DeleteBucketAsync(_bucketName, token);
+                }
+                catch (AmazonS3Exception ex) when (ex.StatusCode == HttpStatusCode.NotFound)
+                {
+                    // Ignore the NotFound exception when deleting the bucket
+                    log.LogWarning($"Transient error may happen during deletion. S3 bucket does not exist any more: {ex.Message}.");
+                }
             }
             _hasBucket = false;
         }


### PR DESCRIPTION
…nt to transient errors.

### Bug Description
We encounter an unhandled exception which is caused by an error code 404 when calling`DeleteBucketAsync` to delete an existing S3 bucket. The exception is unexpected because the existing bucket should be successfully deleted and no 404 exception should be thrown.

We found that the retry mechanism of `DeleteBucketAsync` can actually lead to a 404 error even if the bucket exists when issuing the deletion. More concretely:
1. `DeleteBucketAsync` sends a HTTP request to delete the bucket
2. The bucket is deleted in the remote by the first try but a transient network errors happen (e.g., timeout), so the successful response never arrive the client, instead the transient error code 503 Server Busy may arrive Sleet.
3. The timeout (or transient error code) triggers the SDK API to retry the deletion
4. The second try fails and encounters a 404 error because the bucket has already been deleted by the first try
5. The AWS S3 SDK throws this 404 exception to Sleet

### Expected behavior & Possible Solution
As implemented in this PR:
1. Ignore the 404 error when deleting the bucket.
2. Add a logging of the transient error could help improve the diagnosability.

I hope this can help! Thanks.