### PR TITLE
Set a timeout value for the AmazonS3Client

### DIFF
--- a/src/SleetLib/FileSystem/FileSystemFactory.cs
+++ b/src/SleetLib/FileSystem/FileSystemFactory.cs
@@ -151,6 +151,7 @@ namespace Sleet
                         {
                             config = new AmazonS3Config()
                             {
+                                Timeout = TimeSpan.FromSeconds(10),
                                 ServiceURL = serviceURL,
                                 ProxyCredentials = CredentialCache.DefaultNetworkCredentials
                             };
@@ -159,6 +160,7 @@ namespace Sleet
                         {
                             config = new AmazonS3Config()
                             {
+                                Timeout = TimeSpan.FromSeconds(10),
                                 RegionEndpoint = RegionEndpoint.GetBySystemName(region),
                                 ProxyCredentials = CredentialCache.DefaultNetworkCredentials
                             };

--- a/src/SleetLib/FileSystem/FileSystemFactory.cs
+++ b/src/SleetLib/FileSystem/FileSystemFactory.cs
@@ -151,7 +151,7 @@ namespace Sleet
                         {
                             config = new AmazonS3Config()
                             {
-                                Timeout = TimeSpan.FromSeconds(10),
+                                Timeout = TimeSpan.FromSeconds(100),
                                 ServiceURL = serviceURL,
                                 ProxyCredentials = CredentialCache.DefaultNetworkCredentials
                             };
@@ -160,7 +160,7 @@ namespace Sleet
                         {
                             config = new AmazonS3Config()
                             {
-                                Timeout = TimeSpan.FromSeconds(10),
+                                Timeout = TimeSpan.FromSeconds(100),
                                 RegionEndpoint = RegionEndpoint.GetBySystemName(region),
                                 ProxyCredentials = CredentialCache.DefaultNetworkCredentials
                             };

--- a/test/Sleet.AmazonS3.Tests/AmazonS3TestContext.cs
+++ b/test/Sleet.AmazonS3.Tests/AmazonS3TestContext.cs
@@ -29,7 +29,7 @@ namespace Sleet.AmazonS3.Tests
             var region = Environment.GetEnvironmentVariable(EnvDefaultRegion) ?? "us-east-1";
             AmazonS3Config config = new AmazonS3Config()
                 {
-                    Timeout = TimeSpan.FromSeconds(10),
+                    Timeout = TimeSpan.FromSeconds(100),
                     RegionEndpoint = RegionEndpoint.GetBySystemName(region)
                 };
             Client = new AmazonS3Client(accessKeyId, secretAccessKey, config);

--- a/test/Sleet.AmazonS3.Tests/AmazonS3TestContext.cs
+++ b/test/Sleet.AmazonS3.Tests/AmazonS3TestContext.cs
@@ -27,7 +27,12 @@ namespace Sleet.AmazonS3.Tests
             var accessKeyId = Environment.GetEnvironmentVariable(EnvAccessKeyId);
             var secretAccessKey = Environment.GetEnvironmentVariable(EnvSecretAccessKey);
             var region = Environment.GetEnvironmentVariable(EnvDefaultRegion) ?? "us-east-1";
-            Client = new AmazonS3Client(accessKeyId, secretAccessKey, RegionEndpoint.GetBySystemName(region));
+            AmazonS3Config config = new AmazonS3Config()
+                {
+                    Timeout = TimeSpan.FromSeconds(10),
+                    RegionEndpoint = RegionEndpoint.GetBySystemName(region)
+                };
+            Client = new AmazonS3Client(accessKeyId, secretAccessKey, config);
             Uri = AmazonS3Utility.GetBucketPath(BucketName, region);
 
             FileSystem = new AmazonS3FileSystem(LocalCache, Uri, Client, BucketName);


### PR DESCRIPTION
I found this in the AWS S3 document https://docs.aws.amazon.com/sdk-for-net/v3/developer-guide/retries-timeouts.html: 
> The AWS SDK for .NET enables you to configure the request timeout and socket read/write timeout values at the service client level. These values are specified in the Timeout and the ReadWriteTimeout properties of the abstract [Amazon.Runtime.ClientConfig](https://docs.aws.amazon.com/sdkfornet/v3/apidocs/items/Runtime/TClientConfig.html) class. These values are passed on as the Timeout and ReadWriteTimeout properties of the [HttpWebRequest](https://docs.microsoft.com/en-us/dotnet/api/system.net.httpwebrequest) objects created by the AWS service client object. By default, the Timeout value is 100 seconds and the ReadWriteTimeout value is 300 seconds...
The versions of the AWS SDK for .NET that target the portable class library (PCL) and **.NET Core** set Timeout to the **maximum value** for all [AmazonS3Client](https://docs.aws.amazon.com/sdkfornet/v3/apidocs/items/S3/TS3Client.html) and [AmazonGlacierClient](https://docs.aws.amazon.com/sdkfornet/v3/apidocs/items/Glacier/TGlacierClient.html) objects.

So the AWS SDK will set the largest integer as the timeout by default. Currently, we will always wait for the response to come, which will make the SDK API unresponsive and decrease the efficiency. Even worse, if the response is lost during its delivery, we will wait there forever. In this regard, I manually set the timeout of AmazonS3Client as 10 seconds.



