### PR TITLE
Make the buckect creation more resilient to transie…

### DIFF
--- a/src/SleetLib/FileSystem/AmazonS3FileSystem.cs
+++ b/src/SleetLib/FileSystem/AmazonS3FileSystem.cs
@@ -119,7 +119,15 @@ namespace Sleet
             if (!await HasBucket(log, token))
             {
                 log.LogInformation($"Creating new bucket: {_bucketName}");
-                await _client.EnsureBucketExistsAsync(_bucketName);
+                try 
+                {
+                    await _client.EnsureBucketExistsAsync(_bucketName);
+                }
+                catch (AmazonS3Exception ex) when (ex.StatusCode == HttpStatusCode.Conflict)
+                {
+                    // Ignore the Conflict exception when creating the bucket
+                    log.LogWarning($"Transient error may happen during creation. Bucket already created: {ex.Message}.");
+                }
 
                 var tries = 0;
                 var maxTries = 30;


### PR DESCRIPTION
…nt error

When creating bucket, AWS SDK API `EnsureBucketExistsAsync` is called to create the bucket if it does not exist. However, we found that the transient error may happen during the creation of the bucket, so the retry mechanism will send another request to create the bucket again. Since the bucket has already been created in the first request, a 409 Conflict with "Your previous request to create the named bucket succeeded and you already own it." will appear. 

In this regard, it is better to ignore the 409 error and add a warning level log.

Similar situation (bucket deletion) has been described in: https://github.com/emgarten/Sleet/pull/161