### PR TITLE
Add AWS SSO support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 | AppVeyor | Travis | Azure Pipelines |
 | --- | --- | --- |
-| [![AppVeyor](https://ci.appveyor.com/api/projects/status/cuhdeq60c3ogy7pa?svg=true)](https://ci.appveyor.com/project/emgarten/sleet) | [![Travis](https://travis-ci.com/emgarten/Sleet.svg?branch=main)](https://travis-ci.com/emgarten/Sleet) | [![VSO](https://hackamore.visualstudio.com/_apis/public/build/definitions/abbff132-0981-4267-a80d-a6e7682a75a9/2/badge)](https://github.com/emgarten/sleet) |
+| [![AppVeyor](https://ci.appveyor.com/api/projects/status/cuhdeq60c3ogy7pa?svg=true)](https://ci.appveyor.com/project/emgarten/sleet) | [![VSO](https://hackamore.visualstudio.com/_apis/public/build/definitions/abbff132-0981-4267-a80d-a6e7682a75a9/2/badge)](https://github.com/emgarten/sleet) |
 
 # What is Sleet?
 
@@ -11,9 +11,15 @@ Sleet is a static NuGet package feed generator.
 * **Serverless**. Create static feeds directly on *Azure Storage*, *Amazon S3* or another S3 compatible storage. No compute required.
 * **Cross platform**. Sleet is built in .NET, it can run on *.NET Framework*, *Mono*, or [dotnet CLI](https://github.com/dotnet/cli)
 * **Fast.** Static feeds are created using the [NuGet v3 feed format](https://docs.microsoft.com/en-us/nuget/api/overview).
-* **Symbol server.** Assemblies and pdb files from packages are automatically indexed and provided as a [symbol server](doc/symbol-server.md).
 * **Simple.** Sleet is a simple command line tool that can add, remove, and update packages.
-* **Flexible.** Feeds can be written to disk and hosted with a web server to support authentication. Use the command line tool or a library to run Sleet programmatically.
+* **Flexible.** Configuration and credentials can be set using files, env vars, command line args, or AWS specific patterns to support a variety of workflows and CI builds.
+
+## Why use static feeds?
+
+* Package binaries are typically kept outside of git repos, static feeds provide a long term storage solution that can be paired with checked in code.
+* NuGet feeds are typically read for restore far more than they are updated.
+* Cloud storage accounts are a cheap and secure way to share nupkgs for public feeds.
+* You keep full control of your packages.
 
 ## Getting Sleet
 
@@ -48,13 +54,24 @@ CI builds are located on the following NuGet feed:
 
 The list of packages on this feed is [here](https://nuget.blob.core.windows.net/packages/sleet.packageindex.json).
 
+## Contributing
+
+We welcome contributions. If you are interested in contributing to Sleet report an issue or open a pull request to propose a change.
+
 ## Sleet is..
 
 Cold static packages from the cloud. ☁️ + 📦 = ❄️
 
+## History
+
+Sleet was created to achieve the original goals of the NuGet v3 feed format: Provide maximum availability and performance for NuGet restore by using only static files.
+
+The v3 feed format was designed to do all compute when pushing a new package since updates are infrequent compared to the number of times a package is read for restore. Static files also remove the need to run a specific server to host the feed, allowing a simple file service to handle it.
+
 ## Related projects
 
 * [Sleet.Azure](https://github.com/kzu/Sleet.Azure) provides MSBuild props/targets for running Sleet.
+* [Sleet.Search](https://github.com/emgarten/Sleet.Search) provides a search service for Sleet feeds.
 
 ## License
 

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -3,6 +3,7 @@
 ## 5.1.0
 * Added net7.0 support
 * Update AWS SDK
+* Added AWS SSO profile support
 
 ## 5.0.6
 * Updated NuGet.* packages to 6.2.1

--- a/build/config.props
+++ b/build/config.props
@@ -10,6 +10,8 @@
     <PortablePdbVersion>1.5.0</PortablePdbVersion>
     <AWSSDKVersion>3.7.103.40</AWSSDKVersion>
     <AWSSDKTokenVersion>3.7.101.38</AWSSDKTokenVersion>
+    <AWSSDKSSOVersion>3.7.100.103</AWSSDKSSOVersion>
+    <AWSSDKSSOOIDCVersion>$(AWSSDKSSOVersion)</AWSSDKSSOOIDCVersion>
     <DotNetConfigVersion>1.0.6</DotNetConfigVersion>
   </PropertyGroup>
 

--- a/doc/feed-type-s3.md
+++ b/doc/feed-type-s3.md
@@ -44,6 +44,17 @@ For `.netconfig`, just create or edit the file directly in the [desired location
 
 For details on creating a credentials file go [here](https://docs.aws.amazon.com/sdk-for-net/v2/developer-guide/net-dg-config-creds.html#creds-file)
 
+#### Using SSO profiles
+
+If you are using an SSO profile, you must first log in using the AWS CLI before running sleet to allow SSO profiles to be used.
+
+Sleet will not prompt for SSO login.
+
+```
+aws sso login --profile my-sso-profile
+```
+
+
 ### Using accessKeyId and secretAccessKey in sleet.json
 
 `sleet.json`:

--- a/src/SleetLib/FileSystem/FileSystemFactory.cs
+++ b/src/SleetLib/FileSystem/FileSystemFactory.cs
@@ -172,9 +172,18 @@ namespace Sleet
                         if (!string.IsNullOrWhiteSpace(profileName))
                         {
                             var credFile = new SharedCredentialsFile();
+                            var chain = new CredentialProfileStoreChain();
+
                             if (credFile.TryGetProfile(profileName, out var profile))
                             {
+                                // Successfully created the credentials using the profile
                                 amazonS3Client = new AmazonS3Client(profile.GetAWSCredentials(profileSource: null), config);
+                            }
+                            else if (chain.TryGetAWSCredentials(profileName, out var credentials))
+                            {
+                                // Successfully created the credentials using a profile with SSO
+                                // This works for identities outside of AWS such as Azure AD and Okta
+                                amazonS3Client = new AmazonS3Client(credentials, config);
                             }
                             else
                             {

--- a/src/SleetLib/SleetLib.csproj
+++ b/src/SleetLib/SleetLib.csproj
@@ -20,6 +20,8 @@
   <ItemGroup>
     <PackageReference Include="AWSSDK.S3" Version="$(AWSSDKVersion)" />
     <PackageReference Include="AWSSDK.SecurityToken" Version="$(AWSSDKTokenVersion)" />
+    <PackageReference Include="AWSSDK.SSO" Version="$(AWSSDKSSOVersion)" />
+    <PackageReference Include="AWSSDK.SSOOIDC" Version="$(AWSSDKSSOOIDCVersion)" />
     <PackageReference Include="NuGet.Packaging" Version="$(NuGetPackageVersion)" />
     <PackageReference Include="Microsoft.Azure.Storage.Blob" Version="$(MicrosoftAzureStorageBlobVersion)" />
     <PackageReference Include="Newtonsoft.Json" Version="$(JsonVersion)" />

--- a/src/SleetLib/Utility/AmazonS3Utility.cs
+++ b/src/SleetLib/Utility/AmazonS3Utility.cs
@@ -1,4 +1,6 @@
 using System;
+using Amazon.Runtime;
+using Amazon.Runtime.CredentialManagement;
 
 namespace Sleet
 {
@@ -12,6 +14,15 @@ namespace Sleet
             }
 
             return new Uri($"https://s3-{region}.amazonaws.com/{bucketName}/");
+        }
+
+        public static AWSCredentials LoadSsoCredentials()
+        {
+            var chain = new CredentialProfileStoreChain();
+            if (!chain.TryGetAWSCredentials("my-sso-profile", out var credentials))
+                throw new Exception("Failed to find the my-sso-profile profile");
+
+            return credentials;
         }
     }
 }

--- a/src/SleetLib/Utility/AmazonS3Utility.cs
+++ b/src/SleetLib/Utility/AmazonS3Utility.cs
@@ -1,7 +1,3 @@
-using System;
-using Amazon.Runtime;
-using Amazon.Runtime.CredentialManagement;
-
 namespace Sleet
 {
     public static class AmazonS3Utility
@@ -14,15 +10,6 @@ namespace Sleet
             }
 
             return new Uri($"https://s3-{region}.amazonaws.com/{bucketName}/");
-        }
-
-        public static AWSCredentials LoadSsoCredentials()
-        {
-            var chain = new CredentialProfileStoreChain();
-            if (!chain.TryGetAWSCredentials("my-sso-profile", out var credentials))
-                throw new Exception("Failed to find the my-sso-profile profile");
-
-            return credentials;
         }
     }
 }


### PR DESCRIPTION
Add support for AWS profiles with SSO 

I based this work on: 
https://docs.aws.amazon.com/sdk-for-net/v3/developer-guide/sso.html

It looks relatively straight forward to add, however it is unclear how this works as a fallback with the existing profile support and unfortunately I don't have an SSO account to test this with.

As a fallback this should be safe since the existing profile load runs first. My concern is when looking at the code for the existing profile load I see internally it runs with `isSsoSession: false` and doesn't appear to allow setting it to true.

Potentially an SSO profile could get loaded from the existing profile load. The result may or may not work due to that flag. If it gives incomplete credentials it may return true and not fallback to the new SSO code.

I'm going to go ahead with this change because either way including the AWS SSO SDK binaries looks like a step in the right direction based on the fact that currently Sleet will throw an assembly load exception since those binaries aren't there. The AWS SDK clearly knows about them, but the SDK NuGet package doesn't have a dependency on those. It is up to app to bring them in.

Fixes: https://github.com/emgarten/Sleet/issues/168