### PR TITLE
Fix S3 destroy for feeds with sub paths

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,5 +1,8 @@
 # Release Notes
 
+## 5.2.11
+* AWS S3 feeds with sub paths are now fully removed during destroy.
+
 ## 5.2.6
 * Updated all AWS SDKs to the latest
 

--- a/doc/index.md
+++ b/doc/index.md
@@ -11,3 +11,4 @@
   * [Azure feed](feed-type-azure.md)
   * [AWS S3 feed](feed-type-s3.md)
   * [Integration with CI Server](ci-server.md)
+  * [Setting up a private feed on AWS using S3 + CloudFront + Lambdas](private-feed-s3.md)

--- a/test/Sleet.AmazonS3.Tests/SubFeedTests.cs
+++ b/test/Sleet.AmazonS3.Tests/SubFeedTests.cs
@@ -66,6 +66,9 @@ namespace Sleet.AmazonS3.Tests
                     testContext.FileSystem,
                     testContext.Logger);
 
+                // Validate feed 2 is removed
+                var feed2Files = await testContext2.FileSystem.GetFiles(testContext2.Logger, CancellationToken.None);
+                feed2Files.Should().BeEmpty();
 
                 result.Should().BeTrue();
 


### PR DESCRIPTION
* Updated AmazonS3FileSystem.GetFiles to account for sub paths when retrieving all files in the feed
  * This call is currently only used by Destroy, other scenarios should not be impacted
  * Previous behavior was resulting in the sub path being duplicated in the URI, which resulted in files not being found.
* Updated the S3 sub path functional test to verify the feed is fully removed.

Fixes https://github.com/emgarten/Sleet/issues/185