### PR TITLE
Replace `Microsoft.Azure.Storage.Blob` with `Azure.Storage.Blobs` package

### DIFF
--- a/build/config.props
+++ b/build/config.props
@@ -3,7 +3,7 @@
   <!-- Dependency versions -->
   <PropertyGroup>
     <NuGetPackageVersion>6.9.1</NuGetPackageVersion>
-    <MicrosoftAzureStorageBlobVersion>11.2.3</MicrosoftAzureStorageBlobVersion>
+    <AzureStorageBlobsVersion>12.19.1</AzureStorageBlobsVersion>
     <JsonVersion>13.0.3</JsonVersion>
     <CommandLineUtilsVersion>2.0.0</CommandLineUtilsVersion>
     <NuGetTestHelpersVersion>2.1.36</NuGetTestHelpersVersion>

--- a/doc/ci-server.md
+++ b/doc/ci-server.md
@@ -10,7 +10,7 @@ Github Action is free and common CI/CD tools to developer.
 
 Now we take example to publish some nuget package in Github Action.
 
-You can make it ok with other CI/CD tools like Jeknins, Gitlab Jobs and etc.
+You can make it ok with other CI/CD tools like Jeknins, Gitlab Jobs, etc.
 
 Now, we are going to publish nuget package to Azure by Github Action.
 
@@ -60,10 +60,10 @@ It means:
 
 1. It will run CI action in ubuntu-latest OS
 2. Step named `pack` will `cd` to the `src` directory and try to pack nuget packages versioned `1.0.0`
-3. Step named `Push nuget package to Azure storage` will publish packages placed in `pkgs` diretocy to azure
+3. Step named `Push nuget package to Azure storage` will publish packages placed in `pkgs` directory to azure
 4. \${{secrets.SLEET_CONNECTIONSTRING}} is a secret, you can add it in you repository settings tab.
 
-Put it togather as below:
+Put it together as below:
 
 ```yml
 name: Publish dev nuget package to azure
@@ -99,7 +99,7 @@ jobs:
 
 ### Some tips
 
-#### Please pack nuget package to out it to specfic directory
+#### Please pack nuget package to out it to specific directory
 
 Maybe you publish nuget package via `dotnet` or `nuget` command as script below:
 
@@ -109,4 +109,4 @@ dotnet nuget push **/*.nupkg
 
 Unfortunately, It is not support to publish package via `sleet push **/*.nupkg`.
 
-So, please pack your nuget package to some directory like `pkg` as exmaple above.
+So, please pack your nuget package to some directory like `pkg` as example above.

--- a/src/SleetLib/FileSystem/AzureBlobLease.cs
+++ b/src/SleetLib/FileSystem/AzureBlobLease.cs
@@ -1,7 +1,4 @@
-using System;
 using System.Diagnostics;
-using System.Threading.Tasks;
-using Azure.Storage;
 using Azure.Storage.Blobs;
 
 namespace Sleet

--- a/src/SleetLib/FileSystem/AzureBlobLease.cs
+++ b/src/SleetLib/FileSystem/AzureBlobLease.cs
@@ -1,10 +1,9 @@
-using System.Diagnostics;
+using Azure.Storage.Blobs.Specialized;
 using Azure.Storage.Blobs;
+using System.Diagnostics;
 
 namespace Sleet
 {
-    using Azure.Storage.Blobs.Specialized;
-
     public class AzureBlobLease : IDisposable
     {
         private static readonly TimeSpan _leaseTime = new TimeSpan(0, 1, 0);

--- a/src/SleetLib/FileSystem/AzureBlobLease.cs
+++ b/src/SleetLib/FileSystem/AzureBlobLease.cs
@@ -8,15 +8,14 @@ namespace Sleet
     {
         private static readonly TimeSpan _leaseTime = new TimeSpan(0, 1, 0);
         private readonly BlobClient _blob;
-        private readonly string _leaseId;
 
         public AzureBlobLease(BlobClient blob)
         {
             _blob = blob;
-            _leaseId = Guid.NewGuid().ToString();
+            LeaseId = Guid.NewGuid().ToString();
         }
 
-        public string LeaseId => _leaseId;
+        public string LeaseId { get; }
 
         /// <summary>
         /// Makes a single attempt to get a lease.
@@ -28,21 +27,21 @@ namespace Sleet
 
             try
             {
-                actualLease = (await _blob.GetBlobLeaseClient(_leaseId).AcquireAsync(_leaseTime)).Value.LeaseId;
+                actualLease = (await _blob.GetBlobLeaseClient(LeaseId).AcquireAsync(_leaseTime)).Value.LeaseId;
             }
             catch (Exception ex)
             {
                 Debug.Fail($"GetLease failed: {ex}");
             }
 
-            return StringComparer.Ordinal.Equals(_leaseId, actualLease);
+            return StringComparer.Ordinal.Equals(LeaseId, actualLease);
         }
 
         public async Task Renew()
         {
             try
             {
-                await _blob.GetBlobLeaseClient(_leaseId).RenewAsync();
+                await _blob.GetBlobLeaseClient(LeaseId).RenewAsync();
             }
             catch (Exception ex)
             {
@@ -62,7 +61,7 @@ namespace Sleet
             try
             {
 
-                _blob.GetBlobLeaseClient(_leaseId).ReleaseAsync().Wait(TimeSpan.FromSeconds(60));
+                _blob.GetBlobLeaseClient(LeaseId).ReleaseAsync().Wait(TimeSpan.FromSeconds(60));
             }
             catch (Exception ex)
             {

--- a/src/SleetLib/FileSystem/AzureFile.cs
+++ b/src/SleetLib/FileSystem/AzureFile.cs
@@ -31,7 +31,7 @@ namespace Sleet
 
                 // If the blob is compressed it needs to be decompressed locally before it can be used
                 var blobProperties = await _blob.GetPropertiesAsync(cancellationToken: token);
-                if (blobProperties.HasValue && blobProperties.Value.ContentEncoding.Equals("gzip", StringComparison.OrdinalIgnoreCase))
+                if (blobProperties.Value.ContentEncoding != null && blobProperties.Value.ContentEncoding.Equals("gzip", StringComparison.OrdinalIgnoreCase))
                 {
                     log.LogVerbose($"Decompressing {_blob.Uri.AbsoluteUri}");
 

--- a/src/SleetLib/FileSystem/AzureFile.cs
+++ b/src/SleetLib/FileSystem/AzureFile.cs
@@ -1,8 +1,4 @@
-using System;
-using System.IO;
 using System.IO.Compression;
-using System.Threading;
-using System.Threading.Tasks;
 using Azure.Storage.Blobs;
 using NuGet.Common;
 

--- a/src/SleetLib/FileSystem/AzureFile.cs
+++ b/src/SleetLib/FileSystem/AzureFile.cs
@@ -17,7 +17,7 @@ namespace Sleet
 
         protected override async Task CopyFromSource(ILogger log, CancellationToken token)
         {
-            if (await _blob.ExistsAsync())
+            if (await _blob.ExistsAsync(token))
             {
                 log.LogVerbose($"GET {_blob.Uri.AbsoluteUri}");
 
@@ -58,8 +58,10 @@ namespace Sleet
                 using (var cache = LocalCacheFile.OpenRead())
                 {
                     Stream writeStream = cache;
-                    var blobHeaders = new BlobHttpHeaders();
-                    blobHeaders.CacheControl = "no-store";
+                    var blobHeaders = new BlobHttpHeaders
+                    {
+                        CacheControl = "no-store"
+                    };
 
                     if (_blob.Uri.AbsoluteUri.EndsWith(".nupkg", StringComparison.Ordinal))
                     {

--- a/src/SleetLib/FileSystem/AzureFile.cs
+++ b/src/SleetLib/FileSystem/AzureFile.cs
@@ -1,11 +1,10 @@
-using System.IO.Compression;
+using Azure.Storage.Blobs.Models;
 using Azure.Storage.Blobs;
 using NuGet.Common;
+using System.IO.Compression;
 
 namespace Sleet
 {
-    using Azure.Storage.Blobs.Models;
-
     public class AzureFile : FileBase
     {
         private readonly BlobClient _blob;

--- a/src/SleetLib/FileSystem/AzureFileSystem.cs
+++ b/src/SleetLib/FileSystem/AzureFileSystem.cs
@@ -1,9 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
-using Azure.Storage;
 using Azure.Storage.Blobs;
 using NuGet.Common;
 using Azure.Storage.Blobs.Models;

--- a/src/SleetLib/FileSystem/AzureFileSystem.cs
+++ b/src/SleetLib/FileSystem/AzureFileSystem.cs
@@ -8,7 +8,6 @@ namespace Sleet
     {
         public static readonly string AzureEmptyConnectionString = "DefaultEndpointsProtocol=https;AccountName=;AccountKey=;BlobEndpoint=";
 
-        private readonly BlobServiceClient _blobServiceClient;
         private readonly BlobContainerClient _container;
 
         public AzureFileSystem(LocalCache cache, Uri root, BlobServiceClient blobServiceClient, string container)
@@ -19,8 +18,7 @@ namespace Sleet
         public AzureFileSystem(LocalCache cache, Uri root, Uri baseUri, BlobServiceClient blobServiceClient, string container, string feedSubPath = null)
             : base(cache, root, baseUri, feedSubPath)
         {
-            _blobServiceClient = blobServiceClient;
-            _container = _blobServiceClient.GetBlobContainerClient(container);
+            _container = blobServiceClient.GetBlobContainerClient(container);
 
             var containerUri = UriUtility.EnsureTrailingSlash(_container.Uri);
             var expectedPath = UriUtility.EnsureTrailingSlash(root);
@@ -63,7 +61,7 @@ namespace Sleet
         {
             log.LogInformation($"Verifying {_container.Uri.AbsoluteUri} exists.");
 
-            if (await _container.ExistsAsync())
+            if (await _container.ExistsAsync(token))
             {
                 log.LogInformation($"Found {_container.Uri.AbsoluteUri}");
             }

--- a/src/SleetLib/FileSystem/AzureFileSystemLock.cs
+++ b/src/SleetLib/FileSystem/AzureFileSystemLock.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Threading;
-using System.Threading.Tasks;
 using Azure.Storage.Blobs;
 using Newtonsoft.Json.Linq;
 using NuGet.Common;

--- a/src/SleetLib/FileSystem/FileSystemFactory.cs
+++ b/src/SleetLib/FileSystem/FileSystemFactory.cs
@@ -9,12 +9,14 @@ using Amazon.Runtime.CredentialManagement;
 using Amazon.S3;
 using Amazon.SecurityToken;
 using Amazon.SecurityToken.Model;
-using Microsoft.Azure.Storage;
+using Azure.Storage;
 using Newtonsoft.Json.Linq;
 using NuGetUriUtility = NuGet.Common.UriUtility;
 
 namespace Sleet
 {
+    using Azure.Storage.Blobs;
+
     public static class FileSystemFactory
     {
         /// <summary>
@@ -94,12 +96,13 @@ namespace Sleet
                             throw new ArgumentException("Missing container for azure account.");
                         }
 
-                        var azureAccount = CloudStorageAccount.Parse(connectionString);
+
+                        var blobServiceClient = new BlobServiceClient(connectionString);
 
                         if (pathUri == null)
                         {
                             // Get the default url from the container
-                            pathUri = AzureUtility.GetContainerPath(azureAccount, container);
+                            pathUri = AzureUtility.GetContainerPath(blobServiceClient, container);
                         }
 
                         if (baseUri == null)
@@ -107,7 +110,7 @@ namespace Sleet
                             baseUri = pathUri;
                         }
 
-                        result = new AzureFileSystem(cache, pathUri, baseUri, azureAccount, container, feedSubPath);
+                        result = new AzureFileSystem(cache, pathUri, baseUri, blobServiceClient, container, feedSubPath);
                     }
                     else if (type == "s3")
                     {

--- a/src/SleetLib/SleetLib.csproj
+++ b/src/SleetLib/SleetLib.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="AWSSDK.SSO" Version="$(AWSSDKSSOVersion)" />
     <PackageReference Include="AWSSDK.SSOOIDC" Version="$(AWSSDKSSOOIDCVersion)" />
     <PackageReference Include="NuGet.Packaging" Version="$(NuGetPackageVersion)" />
-    <PackageReference Include="Microsoft.Azure.Storage.Blob" Version="$(MicrosoftAzureStorageBlobVersion)" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="$(AzureStorageBlobsVersion)" />
     <PackageReference Include="Newtonsoft.Json" Version="$(JsonVersion)" />
     <PackageReference Include="Microsoft.DiaSymReader.PortablePdb" Version="$(PortablePdbVersion)" />
     <PackageReference Include="DotNetConfig" Version="$(DotNetConfigVersion)" />

--- a/src/SleetLib/Utility/AzureUtility.cs
+++ b/src/SleetLib/Utility/AzureUtility.cs
@@ -1,29 +1,15 @@
 using System;
-using Microsoft.Azure.Storage;
-using Microsoft.Azure.Storage.Blob;
+using Azure.Storage;
+using Azure.Storage.Blobs;
 
 namespace Sleet
 {
     public static class AzureUtility
     {
-        public static Uri GetContainerPath(CloudStorageAccount azureAccount, string container)
+        public static Uri GetContainerPath(BlobServiceClient blobServiceClient, string container)
         {
-            var client = azureAccount.CreateCloudBlobClient();
-            var blobContainer = client.GetContainerReference(container);
-            return UriUtility.EnsureTrailingSlash(blobContainer.Uri);
-        }
-
-        public static Uri GetContainerAndSubFeedPath(CloudStorageAccount azureAccount, string container, string feedSubPath)
-        {
-            var uri = GetContainerPath(azureAccount, container);
-
-            if (!string.IsNullOrEmpty(feedSubPath))
-            {
-                // Remove any slashes around the feed sub path and append it.
-                uri = UriUtility.EnsureTrailingSlash(UriUtility.GetPath(uri, feedSubPath.Trim('/')));
-            }
-
-            return uri;
+            var blobContainerClient = blobServiceClient.GetBlobContainerClient(container);
+            return UriUtility.EnsureTrailingSlash(blobContainerClient.Uri);
         }
     }
 }

--- a/test/Sleet.Azure.Tests/AzureFileSystemTests.cs
+++ b/test/Sleet.Azure.Tests/AzureFileSystemTests.cs
@@ -1,5 +1,3 @@
-using System.Threading;
-using System.Threading.Tasks;
 using FluentAssertions;
 using Sleet.Test.Common;
 

--- a/test/Sleet.Azure.Tests/AzureNuGetIntegrationTests.cs
+++ b/test/Sleet.Azure.Tests/AzureNuGetIntegrationTests.cs
@@ -1,7 +1,3 @@
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using FluentAssertions;
 using NuGet.Common;
 using NuGet.Protocol;

--- a/test/Sleet.Azure.Tests/AzureTestContext.cs
+++ b/test/Sleet.Azure.Tests/AzureTestContext.cs
@@ -1,12 +1,10 @@
-using System;
-using System.Threading.Tasks;
-using Microsoft.Azure.Storage;
-using Microsoft.Azure.Storage.Blob;
+using Azure.Storage.Blobs;
 using NuGet.Common;
 using NuGet.Test.Helpers;
 
 namespace Sleet.Azure.Tests
 {
+
     public class AzureTestContext : IDisposable
     {
         public LocalSettings LocalSettings { get; }
@@ -17,13 +15,11 @@ namespace Sleet.Azure.Tests
 
         public LocalCache LocalCache { get; }
 
-        public CloudBlobContainer Container { get; }
+        public BlobContainerClient Container { get; }
 
         public Uri Uri => Container.Uri;
 
-        public CloudStorageAccount StorageAccount { get; }
-
-        public CloudBlobClient BlobClient { get; }
+        public BlobServiceClient StorageAccount { get; }
 
         public ILogger Logger { get; }
 
@@ -32,9 +28,8 @@ namespace Sleet.Azure.Tests
         public AzureTestContext()
         {
             ContainerName = $"sleet-test-{Guid.NewGuid().ToString()}";
-            StorageAccount = CloudStorageAccount.Parse(GetConnectionString());
-            BlobClient = StorageAccount.CreateCloudBlobClient();
-            Container = BlobClient.GetContainerReference(ContainerName);
+            StorageAccount = new BlobServiceClient(GetConnectionString());
+            Container = StorageAccount.GetBlobContainerClient(ContainerName);
             LocalCache = new LocalCache();
             LocalSettings = new LocalSettings();
             FileSystem = new AzureFileSystem(LocalCache, Uri, StorageAccount, ContainerName);

--- a/test/Sleet.Azure.Tests/BasicTests.cs
+++ b/test/Sleet.Azure.Tests/BasicTests.cs
@@ -1,15 +1,6 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using FluentAssertions;
-using NuGet.Common;
-using NuGet.Protocol;
-using NuGet.Protocol.Core.Types;
 using NuGet.Test.Helpers;
 using Sleet.Test.Common;
-using Xunit;
 
 namespace Sleet.Azure.Tests
 {

--- a/test/Sleet.Azure.Tests/SubFeedTests.cs
+++ b/test/Sleet.Azure.Tests/SubFeedTests.cs
@@ -1,11 +1,10 @@
+using Azure.Storage.Blobs;
 using FluentAssertions;
 using NuGet.Test.Helpers;
 using Sleet.Test.Common;
 
 namespace Sleet.Azure.Tests
 {
-    using global::Azure.Storage.Blobs;
-
     public class SubFeedTests
     {
         [EnvVarExistsFact(AzureTestContext.EnvVarName)]


### PR DESCRIPTION
Replace `Microsoft.Azure.Storage.Blob` with `Azure.Storage.Blobs` package.

Upgrading is a good idea because
 1. `Microsoft.Azure.Storage.Blob` is no longer supported
 2. `Azure.Storage.Blobs` will get bug fixes/new features
 3. `Azure.Storage.Blobs` supports modern auth (service principals, managed identities)