### PR TITLE
Use the full container uri when path is not set

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,5 +1,8 @@
 # Release Notes
 
+## 6.0.2
+* Fixed a bug where Azure feeds failed when path was not set to the full container URI [Issue](https://github.com/emgarten/Sleet/issues/197)
+
 ## 6.0.0
 * Moved from Microsoft.Azure.Storage.Blob to Azure.Storage.Blobs [PR](https://github.com/emgarten/Sleet/pull/191)
 * Added support for Managed Identity and DefaultAzureCredential with Azure storage accounts [PR](https://github.com/emgarten/Sleet/pull/195)

--- a/doc/feed-type-azure.md
+++ b/doc/feed-type-azure.md
@@ -34,6 +34,42 @@ For `.netconfig`, just create or edit the file directly in the [desired location
     connectionString = "DefaultEndpointsProtocol=https;AccountName=;AccountKey=;BlobEndpoint="
 ```
 
+## Using Microsoft Entra ID
+
+Alternatively you can use Entra ID to provide a service principal or managed identity to access the storage account.
+
+For the list of environment variables that can be used see:
+https://learn.microsoft.com/en-us/dotnet/api/azure.identity.environmentcredential?view=azure-dotnet
+
+`path` must be set to the full uri of the feed including the container name. This gives sleet context on which account and contanier to use the Entra ID with.
+
+Sleet will pick up the environment variables using the Microsoft Identity package and use to authenticate with the storage account.
+
+### sleet.json
+
+```json
+{
+  "sources": [
+    {
+      "name": "feed",
+      "type": "azure",
+      "container": "feed",
+      "path": "https://<your feed>.blob.core.windows.net/feed/"
+    }
+  ]
+}
+```
+
+### .netconfg
+
+```gitconfig
+[sleet "feed"]
+    type = azure
+    container = feed
+    path = "https://<your feed>.blob.core.windows.net/feed/"
+```
+
+
 ## Adding packages
 
 Add packages to the feed with the push command, this can be used with either a path to a single nupkg or a folder of nupkgs.

--- a/src/SleetLib/FileSystem/AzureFileSystem.cs
+++ b/src/SleetLib/FileSystem/AzureFileSystem.cs
@@ -26,7 +26,7 @@ namespace Sleet
             // Verify that the provided path is sane.
             if (!expectedPath.AbsoluteUri.StartsWith(expectedPath.AbsoluteUri, StringComparison.Ordinal))
             {
-                throw new ArgumentException($"Invalid feed path. Azure container {container} resolved to {containerUri.AbsoluteUri} which does not match the provided URI of {expectedPath}  Update path in sleet.json or remove the path property to auto resolve the value.");
+                throw new ArgumentException($"Invalid feed path. Azure container {container} resolved to {containerUri.AbsoluteUri} which does not match the provided URI of {expectedPath}  Update path in sleet.json or remove the path property to auto resolve the value if using a connection string.");
             }
 
             // Compute sub path, ignore the given sub path

--- a/src/SleetLib/Utility/AzureUtility.cs
+++ b/src/SleetLib/Utility/AzureUtility.cs
@@ -1,0 +1,13 @@
+using Azure.Storage.Blobs;
+
+namespace Sleet
+{
+    public static class AzureUtility
+    {
+        public static Uri GetContainerPath(BlobServiceClient blobServiceClient, string container)
+        {
+            var blobContainerClient = blobServiceClient.GetBlobContainerClient(container);
+            return UriUtility.EnsureTrailingSlash(blobContainerClient.Uri);
+        }
+    }
+}

--- a/test/Sleet.Azure.Tests/AzureTestContext.cs
+++ b/test/Sleet.Azure.Tests/AzureTestContext.cs
@@ -63,7 +63,7 @@ namespace Sleet.Azure.Tests
 
         public const string EnvVarName = "SLEET_TEST_ACCOUNT";
 
-        private static string GetConnectionString()
+        public static string GetConnectionString()
         {
             // Use a real azure storage account
             var s = Environment.GetEnvironmentVariable(EnvVarName);


### PR DESCRIPTION
* For Azure connection string scenarios auto populate `path` to the full container URI instead of the storage account URI
* Added a FileSystemFactory test for Azure to ensure this is covered, previous tests were creating an AzureFileSystem directly
* Update azure specific doc to include details on using service principals like the client settings doc.

Fixes https://github.com/emgarten/Sleet/issues/197