### PR TITLE
Update AWS and Azure packages

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## 6.1.0
+* Updated AWS SDK packages to improve support for non AWS S3 storage
+* Updated Azure Storage and Azure Identity packages to fix vulnerability
+
 ## 6.0.2
 * Fixed a bug where Azure feeds failed when path was not set to the full container URI [Issue](https://github.com/emgarten/Sleet/issues/197)
 

--- a/build/config.props
+++ b/build/config.props
@@ -3,7 +3,7 @@
   <!-- Dependency versions -->
   <PropertyGroup>
     <NuGetPackageVersion>6.9.1</NuGetPackageVersion>
-    <AzureStorageBlobsVersion>12.19.1</AzureStorageBlobsVersion>
+    <AzureStorageBlobsVersion>12.20.0</AzureStorageBlobsVersion>
     <JsonVersion>13.0.3</JsonVersion>
     <CommandLineUtilsVersion>2.0.0</CommandLineUtilsVersion>
     <NuGetTestHelpersVersion>2.1.36</NuGetTestHelpersVersion>

--- a/build/config.props
+++ b/build/config.props
@@ -8,12 +8,12 @@
     <CommandLineUtilsVersion>2.0.0</CommandLineUtilsVersion>
     <NuGetTestHelpersVersion>2.1.36</NuGetTestHelpersVersion>
     <PortablePdbVersion>1.5.0</PortablePdbVersion>
-    <AWSSDKVersion>3.7.305.14</AWSSDKVersion>
-    <AWSSDKTokenVersion>3.7.300.40</AWSSDKTokenVersion>
-    <AWSSDKSSOVersion>3.7.300.39</AWSSDKSSOVersion>
-    <AWSSDKSSOOIDCVersion>3.7.301.34</AWSSDKSSOOIDCVersion>
+    <AWSSDKVersion>3.7.310.4</AWSSDKVersion>
+    <AWSSDKTokenVersion>3.7.300.117</AWSSDKTokenVersion>
+    <AWSSDKSSOVersion>3.7.300.116</AWSSDKSSOVersion>
+    <AWSSDKSSOOIDCVersion>3.7.302.27</AWSSDKSSOOIDCVersion>
     <DotNetConfigVersion>1.0.6</DotNetConfigVersion>
-    <AzureIdentityVersion>1.11.2</AzureIdentityVersion>
+    <AzureIdentityVersion>1.12.0</AzureIdentityVersion>
   </PropertyGroup>
 
   <!-- Config -->

--- a/src/SleetLib/FileSystem/FileSystemFactory.cs
+++ b/src/SleetLib/FileSystem/FileSystemFactory.cs
@@ -182,10 +182,13 @@ namespace Sleet
                             amazonS3Client = new AmazonS3Client(new EnvironmentVariablesAWSCredentials(), config);
                         }
                         // Load credentials from an ECS docker container
+                        // Check if the env var GenericContainerCredentials.RelativeURIEnvVariable exists
+                        // Previously this used ECSTaskCredentials.RelativeURIEnvVariable but that was 
+                        // deprecated and the property is now internal on GenericContainerCredentials
                         else if (
-                            !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable(ECSTaskCredentials.ContainerCredentialsURIEnvVariable)))
+                            !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI")))
                         {
-                            amazonS3Client = new AmazonS3Client(new ECSTaskCredentials(), config);
+                            amazonS3Client = new AmazonS3Client(new GenericContainerCredentials(), config);
                         }
                         // Assume IAM role
                         else


### PR DESCRIPTION
* Updated AWS SDK packages to improve support for non AWS S3 storage
* Updated Azure Storage and Azure Identity packages to fix vulnerability
* ECSTaskCredentials -> GenericContainerCredentials
  * ECSTaskCredentials is now deprecated
  * Copied the env var name directly into the code since it is now internal in GenericContainerCredentials