### PR TITLE
add disablePayloadSigning option

### DIFF
--- a/doc/client-settings.md
+++ b/doc/client-settings.md
@@ -77,6 +77,7 @@ More options can be found in the [Azure.Identity README](https://github.com/Azur
 | serverSideEncryptionMethod | The encryption to use for uploaded objects. Only `AES256` and `None` are currently supported. Default is `None`                                                                                                                                                                                                              |
 | compress                   | Compress JSON files with GZIP before uploading. Default is *true*                                                                                                                                                                                                                                                            |
 | acl                        | A acl can be set for uploaded files. By default, no specific canned acl is set and bucket defaults and/or policies are in effect. If the bucket is created by sleet and an acl is set, then the default bucket acl will be set to that acl. |
+|disablePayloadSigning                       | S3 payload signing is a requirement of AWS SigV4, some S3 compatible storage providers do not implement this. Default is `false`
 
 Either `region` or `serviceURL` should be specified but not both.
 

--- a/doc/feed-type-s3.md
+++ b/doc/feed-type-s3.md
@@ -128,7 +128,8 @@ To use [AWS environment variables](https://docs.aws.amazon.com/cli/latest/usergu
       "bucketName": "nupkg",
       "serviceURL": "https://storage.yandexcloud.net",
       "accessKeyId": "IAM_ACCESS_KEY_ID",
-      "secretAccessKey": "IAM_SECRET_ACCESS_KEY"
+      "secretAccessKey": "IAM_SECRET_ACCESS_KEY",
+      "disablePayloadSigning": false, // set to true if SigV4 is not supported by provider (such as Cloudflare R2)
     }
   ]
 }

--- a/src/SleetLib/FileSystem/AmazonS3File.cs
+++ b/src/SleetLib/FileSystem/AmazonS3File.cs
@@ -17,6 +17,7 @@ namespace Sleet
         private readonly bool compress = true;
         private readonly ServerSideEncryptionMethod serverSideEncryptionMethod;
         private readonly S3CannedACL acl;
+        private readonly bool disablePayloadSigning;
 
         internal AmazonS3File(
             AmazonS3FileSystem fileSystem,
@@ -28,7 +29,8 @@ namespace Sleet
             string key,
             ServerSideEncryptionMethod serverSideEncryptionMethod,
             bool compress = true,
-            S3CannedACL acl = null)
+            S3CannedACL acl = null,
+            bool disablePayloadSigning = false)
             : base(fileSystem, rootPath, displayPath, localCacheFile, fileSystem.LocalCache.PerfTracker)
         {
             this.client = client;
@@ -37,6 +39,7 @@ namespace Sleet
             this.compress = compress;
             this.serverSideEncryptionMethod = serverSideEncryptionMethod;
             this.acl = acl;
+            this.disablePayloadSigning = disablePayloadSigning;
         }
 
         protected override async Task CopyFromSource(ILogger log, CancellationToken token)
@@ -134,7 +137,7 @@ namespace Sleet
                     log.LogWarning($"Unknown file type: {absoluteUri}");
                 }
 
-                await UploadFileAsync(client, bucketName, key, contentType, contentEncoding, writeStream, serverSideEncryptionMethod, acl, token)
+                await UploadFileAsync(client, bucketName, key, contentType, contentEncoding, writeStream, serverSideEncryptionMethod, acl, disablePayloadSigning, token)
                     .ConfigureAwait(false);
 
                 writeStream.Dispose();

--- a/src/SleetLib/FileSystem/AmazonS3FileSystemAbstraction.cs
+++ b/src/SleetLib/FileSystem/AmazonS3FileSystemAbstraction.cs
@@ -21,13 +21,15 @@ namespace Sleet
             string key,
             string contentBody,
             ServerSideEncryptionMethod serverSideEncryptionMethod,
+            bool disablePayloadSigning,
             CancellationToken token)
         {
             var putObjectRequest = new PutObjectRequest
             {
                 BucketName = bucketName,
                 Key = key,
-                ContentBody = contentBody
+                ContentBody = contentBody,
+                DisablePayloadSigning = disablePayloadSigning
             };
 
             if (serverSideEncryptionMethod != ServerSideEncryptionMethod.None)
@@ -132,6 +134,7 @@ namespace Sleet
             Stream reader,
             ServerSideEncryptionMethod serverSideEncryptionMethod,
             S3CannedACL acl,
+            bool disablePayloadSigning,
             CancellationToken token)
         {
             var transferUtility = new TransferUtility(client);
@@ -142,7 +145,8 @@ namespace Sleet
                 InputStream = reader,
                 AutoCloseStream = false,
                 AutoResetStreamPosition = false,
-                Headers = { CacheControl = "no-store" }
+                Headers = { CacheControl = "no-store" },
+                DisablePayloadSigning = disablePayloadSigning
             };
 
             if (serverSideEncryptionMethod != ServerSideEncryptionMethod.None)

--- a/src/SleetLib/FileSystem/AmazonS3FileSystemLock.cs
+++ b/src/SleetLib/FileSystem/AmazonS3FileSystemLock.cs
@@ -17,13 +17,15 @@ namespace Sleet
         private readonly string bucketName;
         private readonly IAmazonS3 client;
         private readonly ServerSideEncryptionMethod serverSideEncryptionMethod;
+        private readonly bool disablePayloadSigning;
 
-        public AmazonS3FileSystemLock(IAmazonS3 client, string bucketName, ServerSideEncryptionMethod serverSideEncryptionMethod, ILogger log)
+        public AmazonS3FileSystemLock(IAmazonS3 client, string bucketName, ServerSideEncryptionMethod serverSideEncryptionMethod, bool disablePayloadSigning, ILogger log)
             : base(log)
         {
             this.client = client;
             this.bucketName = bucketName;
             this.serverSideEncryptionMethod = serverSideEncryptionMethod;
+            this.disablePayloadSigning = disablePayloadSigning;
         }
 
         protected override async Task<Tuple<bool, JObject>> TryObtainLockAsync(string lockMessage, CancellationToken token)
@@ -43,7 +45,7 @@ namespace Sleet
                     // Create a new lock
                     json = GetMessageJson(lockMessage);
 
-                    await CreateFileAsync(client, bucketName, LockFile, json.ToString(), serverSideEncryptionMethod, token).ConfigureAwait(false);
+                    await CreateFileAsync(client, bucketName, LockFile, json.ToString(), serverSideEncryptionMethod, disablePayloadSigning, token).ConfigureAwait(false);
 
                     result = true;
                 }

--- a/src/SleetLib/FileSystem/FileSystemFactory.cs
+++ b/src/SleetLib/FileSystem/FileSystemFactory.cs
@@ -101,6 +101,8 @@ namespace Sleet
                         var serverSideEncryptionMethod = JsonUtility.GetValueCaseInsensitive(sourceEntry, "serverSideEncryptionMethod") ?? "None";
                         var compress = JsonUtility.GetBoolCaseInsensitive(sourceEntry, "compress", true);
                         var acl = JsonUtility.GetValueCaseInsensitive(sourceEntry, "acl");
+                        var disablePayloadSigning = JsonUtility.GetBoolCaseInsensitive(sourceEntry, "disablePayloadSigning", false);
+
 
                         if (string.IsNullOrEmpty(bucketName))
                         {
@@ -237,7 +239,8 @@ namespace Sleet
                             serverSideEncryptionMethodValue,
                             feedSubPath,
                             compress,
-                            resolvedAcl
+                            resolvedAcl,
+                            disablePayloadSigning
                         );
                     }
                 }


### PR DESCRIPTION
Some S3 compatible storage such as R2 do not support the Streaming SigV4 implementation used by AWSSDK.S3 which can be bypassed by setting DisablePayloadSigning = true when pushing to S3