### PR TITLE
Add README support

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,7 +1,7 @@
 # Release Notes
 
 ## 6.5.0
-* Added README support. Flatcontainer will now place the README along side the icon and nuspec files. Visual Studio package search will display README files the same as it does for nuget.org.
+* Added README support. Flatcontainer will now place the README alongside the icon and nuspec files. Visual Studio package search will display README files the same as it does for nuget.org.
 
 ## 6.4.0
 * Added disablePayloadSigning option for S3 feeds [PR](https://github.com/emgarten/Sleet/pull/211)

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,5 +1,8 @@
 # Release Notes
 
+## 6.5.0
+* Added README support. Flatcontainer will now place the README along side the icon and nuspec files. Visual Studio package search will display README files the same as it does for nuget.org.
+
 ## 6.4.0
 * Added disablePayloadSigning option for S3 feeds [PR](https://github.com/emgarten/Sleet/pull/211)
 

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 # No options are needed to run a basic build and unit tests
 # To run functional tests against azure and or aws, use the following options:
@@ -26,18 +27,14 @@ while [ : ]; do
         export AWS_DEFAULT_REGION=$2
         shift 2
         ;;
-    --) shift; 
-        break 
+    --) shift;
+        break
         ;;
   esac
 done
 
-RESULTCODE=0
 pushd $(pwd)
 
 # Download dotnet cli and run tests
 . build/common/common.sh
 run_standard_tests
-
-popd
-exit $RESULTCODE

--- a/build/config.props
+++ b/build/config.props
@@ -6,7 +6,7 @@
     <AzureStorageBlobsVersion>12.20.0</AzureStorageBlobsVersion>
     <JsonVersion>13.0.3</JsonVersion>
     <CommandLineUtilsVersion>2.0.0</CommandLineUtilsVersion>
-    <NuGetTestHelpersVersion>2.1.36</NuGetTestHelpersVersion>
+    <NuGetTestHelpersVersion>2.1.39</NuGetTestHelpersVersion>
     <PortablePdbVersion>1.5.0</PortablePdbVersion>
     <AWSSDKVersion>3.7.310.4</AWSSDKVersion>
     <AWSSDKTokenVersion>3.7.300.117</AWSSDKTokenVersion>

--- a/src/SleetLib/Commands/InitCommand.cs
+++ b/src/SleetLib/Commands/InitCommand.cs
@@ -2,7 +2,6 @@ using System;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Web;
 using Newtonsoft.Json.Linq;
 using NuGet.Common;
 

--- a/src/SleetLib/Commands/InitCommand.cs
+++ b/src/SleetLib/Commands/InitCommand.cs
@@ -2,6 +2,7 @@ using System;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Web;
 using Newtonsoft.Json.Linq;
 using NuGet.Common;
 
@@ -95,6 +96,7 @@ namespace Sleet
             AddServiceIndexEntry(source.BaseURI, "registration/", "RegistrationsBaseUrl/3.4.0", "Package registrations used for search and packages.config.", serviceIndexJson);
             AddServiceIndexEntry(source.BaseURI, "", "ReportAbuseUriTemplate/3.0.0", "Report abuse template.", serviceIndexJson);
             AddServiceIndexEntry(source.BaseURI, "flatcontainer/", "PackageBaseAddress/3.0.0", "Packages used by project.json", serviceIndexJson);
+            AddServiceIndexEntry(source.BaseURI, "flatcontainer/{lower_id}/{lower_version}/readme", "ReadmeUriTemplate/6.13.0", "URI template used by NuGet Client to construct a URL for downloading a package's README.", serviceIndexJson);
 
             // Add symbols feed if enabled
             if (feedSettings.SymbolsEnabled)
@@ -151,10 +153,15 @@ namespace Sleet
         private static JObject GetServiceIndexEntry(Uri baseUri, string relativeFilePath, string type, string comment)
         {
             var id = UriUtility.GetPath(baseUri, relativeFilePath);
+            var url = id.AbsoluteUri;
+
+            // Remove encoding for templates
+            url = url.Replace("%7Blower_id%7D", "{lower_id}");
+            url = url.Replace("%7Blower_version%7D", "{lower_version}");
 
             var json = new JObject
             {
-                ["@id"] = id.AbsoluteUri,
+                ["@id"] = url,
                 ["@type"] = type,
                 ["comment"] = comment
             };

--- a/src/SleetLib/FileSystem/AmazonS3File.cs
+++ b/src/SleetLib/FileSystem/AmazonS3File.cs
@@ -132,6 +132,10 @@ namespace Sleet
                 {
                     contentType = "image/png";
                 }
+                else if (absoluteUri.AbsoluteUri.EndsWith("/readme"))
+                {
+                    contentType = "text/markdown";
+                }
                 else
                 {
                     log.LogWarning($"Unknown file type: {absoluteUri}");

--- a/src/SleetLib/FileSystem/AzureFile.cs
+++ b/src/SleetLib/FileSystem/AzureFile.cs
@@ -96,6 +96,10 @@ namespace Sleet
                     {
                         blobHeaders.ContentType = "image/png";
                     }
+                    else if (_blob.Uri.AbsoluteUri.EndsWith("/readme"))
+                    {
+                        blobHeaders.ContentType = "text/markdown";
+                    }
                     else
                     {
                         log.LogWarning($"Unknown file type: {_blob.Uri.AbsoluteUri}");

--- a/test/Sleet.AmazonS3.Tests/BasicTests.cs
+++ b/test/Sleet.AmazonS3.Tests/BasicTests.cs
@@ -170,7 +170,36 @@ namespace Sleet.AmazonS3.Tests
             {
                 await testContext.InitAsync();
 
-                var testPackage = new TestNupkg("packageA", "1.0.0");
+                var testPackage = new TestNupkg()
+                {
+                    Nuspec = new TestNuspec()
+                    {
+                        Id = "packageA",
+                        Version = "1.0.0",
+                        Authors = "author",
+                        Description = "desc",
+                        IconUrl = "http://www.tempuri.org",
+                        Icon = "images/icon.png",
+                        Readme = "README.md",
+                        Language = "en-us",
+                        MinClientVersion = "1.0.0",
+                        Title = "title",
+                        Tags = "a b d",
+                        Summary = "summary",
+                        LicenseUrl = "http://www.tempuri.org/lic",
+                        ProjectUrl = "http://www.tempuri.org/proj",
+                        ReleaseNotes = "notes",
+                        Owners = "owners",
+                        Copyright = "copyright",
+                        RequireLicenseAcceptance = "true"
+                    },
+                    Files = new List<TestNupkgFile>()
+                    {
+                        new("README.md"),
+                        new("images/icon.png")
+                    }
+                };
+
                 var zipFile = testPackage.Save(packagesFolder.Root);
 
                 var result = await InitCommand.RunAsync(testContext.LocalSettings,

--- a/test/Sleet.Azure.Tests/BasicTests.cs
+++ b/test/Sleet.Azure.Tests/BasicTests.cs
@@ -137,7 +137,36 @@ namespace Sleet.Azure.Tests
             {
                 await testContext.InitAsync();
 
-                var testPackage = new TestNupkg("packageA", "1.0.0");
+                var testPackage = new TestNupkg()
+                {
+                    Nuspec = new TestNuspec()
+                    {
+                        Id = "packageA",
+                        Version = "1.0.0",
+                        Authors = "author",
+                        Description = "desc",
+                        IconUrl = "http://www.tempuri.org",
+                        Icon = "images/icon.png",
+                        Readme = "README.md",
+                        Language = "en-us",
+                        MinClientVersion = "1.0.0",
+                        Title = "title",
+                        Tags = "a b d",
+                        Summary = "summary",
+                        LicenseUrl = "http://www.tempuri.org/lic",
+                        ProjectUrl = "http://www.tempuri.org/proj",
+                        ReleaseNotes = "notes",
+                        Owners = "owners",
+                        Copyright = "copyright",
+                        RequireLicenseAcceptance = "true"
+                    },
+                    Files = new List<TestNupkgFile>()
+                    {
+                        new("README.md"),
+                        new("images/icon.png")
+                    }
+                };
+
                 var zipFile = testPackage.Save(packagesFolder.Root);
 
                 var result = await InitCommand.RunAsync(testContext.LocalSettings,

--- a/test/SleetLib.Tests/InitCommandTests.cs
+++ b/test/SleetLib.Tests/InitCommandTests.cs
@@ -118,6 +118,7 @@ namespace SleetLib.Tests
                 rootJson.ToString().Should().Contain("catalog/index.json");
                 rootJson.ToString().Should().Contain("Catalog/3.0.0");
                 rootJson.ToString().Should().Contain("symbols/packages/index.json");
+                rootJson.ToString().Should().Contain("ReadmeUriTemplate/6.13.0");
             }
         }
 


### PR DESCRIPTION
* Update NuGet.Test.Helpers to get support for readme files in test packages
* README files (if they exist) will now be copied to the flatcontainer folder for that package version along side the icon, nuspec, and nupkg
   * readme files have a content type of `text/markdown` 
   * Files are NOT compressed, this doesn't work with Visual Studio in my testing
* This feature is always on, there isn't a good reason to disable this or make it optional
* The service index json file will now have an entry added for the template to build the README url
   * Existing feeds will need to do a `recreate` to update the index or may have to edit it manually to get Visual Studio to pick it up



Fixes https://github.com/emgarten/Sleet/issues/212