### PR TITLE
Fix path validation and proxy init

### DIFF
--- a/src/Sleet/Util.cs
+++ b/src/Sleet/Util.cs
@@ -16,7 +16,10 @@ namespace Sleet
             var proxySettings = settings?.Json?["proxy"] ?? new JObject();
             if (proxySettings["useDefaultCredentials"]?.ToObject<bool>() == true)
             {
-                WebRequest.DefaultWebProxy.Credentials = CredentialCache.DefaultCredentials;
+                if (WebRequest.DefaultWebProxy != null)
+                {
+                    WebRequest.DefaultWebProxy.Credentials = CredentialCache.DefaultCredentials;
+                }
             }
         }
 

--- a/src/SleetLib/FileSystem/AzureFileSystem.cs
+++ b/src/SleetLib/FileSystem/AzureFileSystem.cs
@@ -24,7 +24,7 @@ namespace Sleet
             var expectedPath = UriUtility.EnsureTrailingSlash(root);
 
             // Verify that the provided path is sane.
-            if (!expectedPath.AbsoluteUri.StartsWith(expectedPath.AbsoluteUri, StringComparison.Ordinal))
+            if (!expectedPath.AbsoluteUri.StartsWith(containerUri.AbsoluteUri, StringComparison.Ordinal))
             {
                 throw new ArgumentException($"Invalid feed path. Azure container {container} resolved to {containerUri.AbsoluteUri} which does not match the provided URI of {expectedPath}  Update path in sleet.json or remove the path property to auto resolve the value if using a connection string.");
             }


### PR DESCRIPTION
## Summary
- ensure Azure file system validates container path correctly
- guard against null proxy when setting credentials