### PR TITLE
fix json parsing error on upload

### DIFF
--- a/src/SleetLib/FileSystem/AmazonS3File.cs
+++ b/src/SleetLib/FileSystem/AmazonS3File.cs
@@ -115,6 +115,14 @@ namespace Sleet
                 {
                     contentType = "image/svg+xml";
                 }
+                else if (absoluteUri.AbsoluteUri.EndsWith("/icon"))
+                {
+                    contentType = "image/png";
+                }
+                else if (absoluteUri.AbsoluteUri.EndsWith("/readme"))
+                {
+                    contentType = "text/markdown";
+                }
                 else if (key.EndsWith(".json", StringComparison.Ordinal)
                          || await JsonUtility.IsJsonAsync(LocalCacheFile.FullName))
                 {
@@ -130,14 +138,6 @@ namespace Sleet
                          || key.EndsWith(".pdb", StringComparison.OrdinalIgnoreCase))
                 {
                     contentType = "application/octet-stream";
-                }
-                else if (absoluteUri.AbsoluteUri.EndsWith("/icon"))
-                {
-                    contentType = "image/png";
-                }
-                else if (absoluteUri.AbsoluteUri.EndsWith("/readme"))
-                {
-                    contentType = "text/markdown";
                 }
                 else
                 {


### PR DESCRIPTION
When trying to push a nuget package containing an icon and a readme inside the nupkg (such as libvlcsharp), I'm hitting the following error:
```
Unexpected character encountered while parsing value: �. Path '', line 0, position 0 
```

You can reproduce and catch the exception here https://github.com/emgarten/Sleet/blob/52ac190624373706eb66f6a1a4325dbe879f15dd/src/SleetLib/Utility/JsonUtility.cs#L178

readmes and icons are under the form of `bc843690-b6b7-44f9-9527-bab8a374809e\07e7da76-8654-4d33-8f2f-aa9dafec230b.tmp` for `LocalCacheFile.FullName` and the current `if` logic is not detecting them early enough, so I just moved them around.