### PR TITLE
Added `immutableCacheControl` and `mutableCacheControl` configuration

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## 7.1.0
+* Added `immutableCacheControl` and `mutableCacheControl` configuration options for Azure Storage and Amazon S3 feeds
+  * `immutableCacheControl` - Controls caching for versioned immutable files (.nupkg, .nuspec, .xml, .dll, .pdb, icons, readmes). Default: `no-cache`
+  * `mutableCacheControl` - Controls caching for mutable feed metadata (.json, .svg). Default: `no-cache`
+  * Both settings support standard Cache-Control header values (e.g., `public, max-age=31536000, immutable`)
+
 ## 7.0.0
 * Add net10.0 support, remove netstandard2.0, net6.0 support
 * Update NuGet.* packages to 7.0.1

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -2,8 +2,8 @@
 
 ## 7.1.0
 * Added `immutableCacheControl` and `mutableCacheControl` configuration options for Azure Storage and Amazon S3 feeds
-  * `immutableCacheControl` - Controls caching for versioned immutable files (.nupkg, .nuspec, .xml, .dll, .pdb, icons, readmes). Default: `no-cache`
-  * `mutableCacheControl` - Controls caching for mutable feed metadata (.json, .svg). Default: `no-cache`
+  * `immutableCacheControl` - Controls caching for versioned immutable files (.nupkg, .nuspec, .xml, .dll, .pdb, icons, readmes). Default: `no-store`
+  * `mutableCacheControl` - Controls caching for mutable feed metadata (.json, .svg). Default: `no-store`
   * Both settings support standard Cache-Control header values (e.g., `public, max-age=31536000, immutable`)
 
 ## 7.0.0

--- a/doc/client-settings.md
+++ b/doc/client-settings.md
@@ -254,7 +254,7 @@ It is possible to configure caching header for both Azure and S3 backed feeds. T
 
 | Property                   | Description                                                                                                                                                          |
 |----------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| immutableCacheControl      | Cache-Control header value for immutable versioned files (.nupkg, .nuspec, .xml, .dll, .pdb). Default is `no-store`. Example: `public, max-age=31536000, immutable`  |
+| immutableCacheControl      | Cache-Control header value for immutable versioned files (.nupkg, /readme, /icon, .nuspec, .xml, .dll, .pdb). Default is `no-store`. Example: `public, max-age=31536000, immutable`  |
 | mutableCacheControl        | Cache-Control header value for mutable files (.json, .svg). Default is `no-store`. Example: `public, max-age=300, must-revalidate`                                   |
 
 ## Sleet.json loading order

--- a/doc/client-settings.md
+++ b/doc/client-settings.md
@@ -250,12 +250,12 @@ Tokens that resolve to a tokenized string will also be resolved, allowing enviro
 To escape `$` use `$$`.
 
 ## Caching configuration
-It is possible to configure caching header for both Azure and S3 backed feeds. This is useful when serving the feed content through a CDN. By default, caching is disabled with a value of `no-cache`. You can configure caching for both mutable and immutable files. Immutable files (files which aren't supposed to change, since they are stored per version - `.nupkg`, `/readme`, `/icon`, `.nuspec`, `.xml`, `.dll`, `.pdb`) should have a long cache lifetime (unless you are making changes to live packages). Mutable files (files which are expected to change, such as `index.json` and `flatcontainer/{id}/index.json`) should have a short cache lifetime (~1 hour or whatever you are comfortable with), since it can make clients see stale feed.
+It is possible to configure caching header for both Azure and S3 backed feeds. This is useful when serving the feed content through a CDN. By default, caching is disabled with a value of `no-store`. You can configure caching for both mutable and immutable files. Immutable files (files which aren't supposed to change, since they are stored per version - `.nupkg`, `/readme`, `/icon`, `.nuspec`, `.xml`, `.dll`, `.pdb`) should have a long cache lifetime (unless you are making changes to live packages). Mutable files (files which are expected to change, such as `index.json` and `flatcontainer/{id}/index.json`) should have a short cache lifetime (~1 hour or whatever you are comfortable with), since it can make clients see stale feed.
 
 | Property                   | Description                                                                                                                                                          |
 |----------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| immutableCacheControl      | Cache-Control header value for immutable versioned files (.nupkg, .nuspec, .xml, .dll, .pdb). Default is `no-cache`. Example: `public, max-age=31536000, immutable`  |
-| mutableCacheControl        | Cache-Control header value for mutable files (.json, .svg). Default is `no-cache`. Example: `public, max-age=300, must-revalidate`                                   |
+| immutableCacheControl      | Cache-Control header value for immutable versioned files (.nupkg, .nuspec, .xml, .dll, .pdb). Default is `no-store`. Example: `public, max-age=31536000, immutable`  |
+| mutableCacheControl        | Cache-Control header value for mutable files (.json, .svg). Default is `no-store`. Example: `public, max-age=300, must-revalidate`                                   |
 
 ## Sleet.json loading order
 

--- a/doc/client-settings.md
+++ b/doc/client-settings.md
@@ -249,6 +249,14 @@ Tokens that resolve to a tokenized string will also be resolved, allowing enviro
 
 To escape `$` use `$$`.
 
+## Caching configuration
+It is possible to configure caching header for both Azure and S3 backed feeds. This is useful when serving the feed content through a CDN. By default, caching is disabled with a value of `no-cache`. You can configure caching for both mutable and immutable files. Immutable files (files which aren't supposed to change, since they are stored per version - `.nupkg`, `/readme`, `/icon`, `.nuspec`, `.xml`, `.dll`, `.pdb`) should have a long cache lifetime (unless you are making changes to live packages). Mutable files (files which are expected to change, such as `index.json` and `flatcontainer/{id}/index.json`) should have a short cache lifetime (~1 hour or whatever you are comfortable with), since it can make clients see stale feed.
+
+| Property                   | Description                                                                                                                                                          |
+|----------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| immutableCacheControl      | Cache-Control header value for immutable versioned files (.nupkg, .nuspec, .xml, .dll, .pdb). Default is `no-cache`. Example: `public, max-age=31536000, immutable`  |
+| mutableCacheControl        | Cache-Control header value for mutable files (.json, .svg). Default is `no-cache`. Example: `public, max-age=300, must-revalidate`                                   |
+
 ## Sleet.json loading order
 
 1. If `--config` was passed the path given will be used.

--- a/src/SleetLib/FileSystem/AmazonS3File.cs
+++ b/src/SleetLib/FileSystem/AmazonS3File.cs
@@ -105,7 +105,7 @@ namespace Sleet
             using (var cache = LocalCacheFile.OpenRead())
             {
                 Stream writeStream = cache;
-                string? contentType = null, contentEncoding = null, cacheControl = "no-cache";
+                string? contentType = null, contentEncoding = null, cacheControl = "no-store";
                 var disposeWriteStream = false;
 
                 if (key.EndsWith(".nupkg", StringComparison.OrdinalIgnoreCase))

--- a/src/SleetLib/FileSystem/AmazonS3File.cs
+++ b/src/SleetLib/FileSystem/AmazonS3File.cs
@@ -18,6 +18,8 @@ namespace Sleet
         private readonly ServerSideEncryptionMethod serverSideEncryptionMethod;
         private readonly S3CannedACL? acl;
         private readonly bool disablePayloadSigning;
+        private readonly string immutableCacheControl;
+        private readonly string mutableCacheControl;
 
         internal AmazonS3File(
             AmazonS3FileSystem fileSystem,
@@ -30,7 +32,9 @@ namespace Sleet
             ServerSideEncryptionMethod serverSideEncryptionMethod,
             bool compress = true,
             S3CannedACL? acl = null,
-            bool disablePayloadSigning = false)
+            bool disablePayloadSigning = false,
+            string? immutableCacheControl = null,
+            string? mutableCacheControl = null)
             : base(fileSystem, rootPath, displayPath, localCacheFile, fileSystem.LocalCache.PerfTracker)
         {
             this.client = client;
@@ -40,6 +44,8 @@ namespace Sleet
             this.serverSideEncryptionMethod = serverSideEncryptionMethod;
             this.acl = acl;
             this.disablePayloadSigning = disablePayloadSigning;
+            this.immutableCacheControl = immutableCacheControl ?? "no-cache";
+            this.mutableCacheControl = mutableCacheControl ?? "no-cache";
         }
 
         protected override async Task CopyFromSource(ILogger log, CancellationToken token)
@@ -99,33 +105,39 @@ namespace Sleet
             using (var cache = LocalCacheFile.OpenRead())
             {
                 Stream writeStream = cache;
-                string? contentType = null, contentEncoding = null;
+                string? contentType = null, contentEncoding = null, cacheControl = "no-cache";
                 var disposeWriteStream = false;
 
                 if (key.EndsWith(".nupkg", StringComparison.OrdinalIgnoreCase))
                 {
                     contentType = "application/zip";
+                    cacheControl = immutableCacheControl;
                 }
                 else if (key.EndsWith(".xml", StringComparison.OrdinalIgnoreCase)
                          || key.EndsWith(".nuspec", StringComparison.OrdinalIgnoreCase))
                 {
                     contentType = "application/xml";
+                    cacheControl = immutableCacheControl;
                 }
                 else if (key.EndsWith(".svg", StringComparison.OrdinalIgnoreCase))
                 {
                     contentType = "image/svg+xml";
+                    cacheControl = mutableCacheControl;
                 }
                 else if (absoluteUri.AbsoluteUri.EndsWith("/icon", StringComparison.Ordinal))
                 {
                     contentType = "image/png";
+                    cacheControl = immutableCacheControl;
                 }
                 else if (absoluteUri.AbsoluteUri.EndsWith("/readme", StringComparison.Ordinal))
                 {
                     contentType = "text/markdown";
+                    cacheControl = immutableCacheControl;
                 }
                 else if (key.EndsWith(".json", StringComparison.OrdinalIgnoreCase)
                          || await JsonUtility.IsJsonAsync(LocalCacheFile.FullName))
                 {
+                    cacheControl = mutableCacheControl;
                     contentType = "application/json";
                     if (compress && !SkipCompress())
                     {
@@ -137,6 +149,7 @@ namespace Sleet
                 else if (key.EndsWith(".dll", StringComparison.OrdinalIgnoreCase)
                          || key.EndsWith(".pdb", StringComparison.OrdinalIgnoreCase))
                 {
+                    cacheControl = immutableCacheControl;
                     contentType = "application/octet-stream";
                 }
                 else
@@ -146,7 +159,7 @@ namespace Sleet
 
                 try
                 {
-                    await UploadFileAsync(client, bucketName, key, contentType, contentEncoding, writeStream, serverSideEncryptionMethod, acl, disablePayloadSigning, token)
+                    await UploadFileAsync(client, bucketName, key, contentType, contentEncoding, writeStream, serverSideEncryptionMethod, acl, disablePayloadSigning, cacheControl, token)
                         .ConfigureAwait(false);
                 }
                 finally

--- a/src/SleetLib/FileSystem/AmazonS3File.cs
+++ b/src/SleetLib/FileSystem/AmazonS3File.cs
@@ -44,8 +44,8 @@ namespace Sleet
             this.serverSideEncryptionMethod = serverSideEncryptionMethod;
             this.acl = acl;
             this.disablePayloadSigning = disablePayloadSigning;
-            this.immutableCacheControl = immutableCacheControl ?? "no-cache";
-            this.mutableCacheControl = mutableCacheControl ?? "no-cache";
+            this.immutableCacheControl = immutableCacheControl ?? "no-store";
+            this.mutableCacheControl = mutableCacheControl ?? "no-store";
         }
 
         protected override async Task CopyFromSource(ILogger log, CancellationToken token)

--- a/src/SleetLib/FileSystem/AmazonS3FileSystem.cs
+++ b/src/SleetLib/FileSystem/AmazonS3FileSystem.cs
@@ -16,6 +16,8 @@ namespace Sleet
         private readonly ServerSideEncryptionMethod _serverSideEncryptionMethod;
         private readonly S3CannedACL? _acl;
         private readonly bool _disablePayloadSigning;
+        private readonly string _immutableCacheControl;
+        private readonly string _mutableCacheControl;
 
         private bool? _hasBucket;
 
@@ -34,7 +36,9 @@ namespace Sleet
             string? feedSubPath = null,
             bool compress = true,
             S3CannedACL? acl = null,
-            bool disablePayloadSigning = false)
+            bool disablePayloadSigning = false,
+            string? immutableCacheControl = null,
+            string? mutableCacheControl = null)
             : base(cache, root, baseUri)
         {
             _client = client;
@@ -42,6 +46,8 @@ namespace Sleet
             _serverSideEncryptionMethod = serverSideEncryptionMethod;
             _acl = acl;
             _disablePayloadSigning = disablePayloadSigning;
+            _immutableCacheControl = immutableCacheControl ?? "no-cache";
+            _mutableCacheControl = mutableCacheControl ?? "no-cache";
 
             if (!string.IsNullOrEmpty(feedSubPath))
             {
@@ -117,7 +123,7 @@ namespace Sleet
         private AmazonS3File CreateAmazonS3File(SleetUriPair pair)
         {
             var key = GetRelativePath(pair.Root);
-            return new AmazonS3File(this, pair.Root, pair.BaseURI, LocalCache.GetNewTempPath(), _client, _bucketName, key, _serverSideEncryptionMethod, _compress, _acl, _disablePayloadSigning);
+            return new AmazonS3File(this, pair.Root, pair.BaseURI, LocalCache.GetNewTempPath(), _client, _bucketName, key, _serverSideEncryptionMethod, _compress, _acl, _disablePayloadSigning, _immutableCacheControl, _mutableCacheControl);
         }
 
         public override string GetRelativePath(Uri uri)

--- a/src/SleetLib/FileSystem/AmazonS3FileSystem.cs
+++ b/src/SleetLib/FileSystem/AmazonS3FileSystem.cs
@@ -46,8 +46,8 @@ namespace Sleet
             _serverSideEncryptionMethod = serverSideEncryptionMethod;
             _acl = acl;
             _disablePayloadSigning = disablePayloadSigning;
-            _immutableCacheControl = immutableCacheControl ?? "no-cache";
-            _mutableCacheControl = mutableCacheControl ?? "no-cache";
+            _immutableCacheControl = immutableCacheControl ?? "no-store";
+            _mutableCacheControl = mutableCacheControl ?? "no-store";
 
             if (!string.IsNullOrEmpty(feedSubPath))
             {

--- a/src/SleetLib/FileSystem/AmazonS3FileSystemAbstraction.cs
+++ b/src/SleetLib/FileSystem/AmazonS3FileSystemAbstraction.cs
@@ -131,6 +131,7 @@ namespace Sleet
             ServerSideEncryptionMethod serverSideEncryptionMethod,
             S3CannedACL? acl,
             bool disablePayloadSigning,
+            string? cacheControl,
             CancellationToken token)
         {
             var transferUtility = new TransferUtility(client);
@@ -141,7 +142,7 @@ namespace Sleet
                 InputStream = reader,
                 AutoCloseStream = false,
                 AutoResetStreamPosition = false,
-                Headers = { CacheControl = "no-store" },
+                Headers = { CacheControl = cacheControl ?? "no-store" },
                 DisablePayloadSigning = disablePayloadSigning
             };
 

--- a/src/SleetLib/FileSystem/AzureFile.cs
+++ b/src/SleetLib/FileSystem/AzureFile.cs
@@ -8,11 +8,15 @@ namespace Sleet
     public class AzureFile : FileBase
     {
         private readonly BlobClient _blob;
+        private readonly string _immutableCacheControl;
+        private readonly string _mutableCacheControl;
 
-        internal AzureFile(AzureFileSystem fileSystem, Uri rootPath, Uri displayPath, FileInfo localCacheFile, BlobClient blob)
+        internal AzureFile(AzureFileSystem fileSystem, Uri rootPath, Uri displayPath, FileInfo localCacheFile, BlobClient blob, string immutableCacheControl, string mutableCacheControl)
             : base(fileSystem, rootPath, displayPath, localCacheFile, fileSystem.LocalCache.PerfTracker)
         {
             _blob = blob;
+            _immutableCacheControl = immutableCacheControl;
+            _mutableCacheControl = mutableCacheControl;
         }
 
         protected override async Task CopyFromSource(ILogger log, CancellationToken token)
@@ -67,20 +71,24 @@ namespace Sleet
                     if (_blob.Uri.AbsoluteUri.EndsWith(".nupkg", StringComparison.OrdinalIgnoreCase))
                     {
                         blobHeaders.ContentType = "application/zip";
+                        blobHeaders.CacheControl = _immutableCacheControl;
                     }
                     else if (_blob.Uri.AbsoluteUri.EndsWith(".xml", StringComparison.OrdinalIgnoreCase)
                         || _blob.Uri.AbsoluteUri.EndsWith(".nuspec", StringComparison.OrdinalIgnoreCase))
                     {
                         blobHeaders.ContentType = "application/xml";
+                        blobHeaders.CacheControl = _immutableCacheControl;
                     }
                     else if (_blob.Uri.AbsoluteUri.EndsWith(".svg", StringComparison.OrdinalIgnoreCase))
                     {
                         blobHeaders.ContentType = "image/svg+xml";
+                        blobHeaders.CacheControl = _mutableCacheControl;
                     }
                     else if (_blob.Uri.AbsoluteUri.EndsWith(".json", StringComparison.OrdinalIgnoreCase)
                             || await JsonUtility.IsJsonAsync(LocalCacheFile.FullName))
                     {
                         blobHeaders.ContentType = "application/json";
+                        blobHeaders.CacheControl = _mutableCacheControl;
 
                         if (!SkipCompress())
                         {
@@ -93,14 +101,17 @@ namespace Sleet
                         || _blob.Uri.AbsoluteUri.EndsWith(".pdb", StringComparison.OrdinalIgnoreCase))
                     {
                         blobHeaders.ContentType = "application/octet-stream";
+                        blobHeaders.CacheControl = _immutableCacheControl;
                     }
                     else if (_blob.Uri.AbsoluteUri.EndsWith("/icon", StringComparison.Ordinal))
                     {
                         blobHeaders.ContentType = "image/png";
+                        blobHeaders.CacheControl = _immutableCacheControl;
                     }
                     else if (_blob.Uri.AbsoluteUri.EndsWith("/readme", StringComparison.Ordinal))
                     {
                         blobHeaders.ContentType = "text/markdown";
+                        blobHeaders.CacheControl = _immutableCacheControl;
                     }
                     else
                     {

--- a/src/SleetLib/FileSystem/AzureFileSystem.cs
+++ b/src/SleetLib/FileSystem/AzureFileSystem.cs
@@ -9,16 +9,20 @@ namespace Sleet
         public static readonly string AzureEmptyConnectionString = "DefaultEndpointsProtocol=https;AccountName=;AccountKey=;BlobEndpoint=";
 
         private readonly BlobContainerClient _container;
+        private readonly string _immutableCacheControl;
+        private readonly string _mutableCacheControl;
 
         public AzureFileSystem(LocalCache cache, Uri root, BlobServiceClient blobServiceClient, string container)
             : this(cache, root, root, blobServiceClient, container)
         {
         }
 
-        public AzureFileSystem(LocalCache cache, Uri root, Uri baseUri, BlobServiceClient blobServiceClient, string container, string? feedSubPath = null)
+        public AzureFileSystem(LocalCache cache, Uri root, Uri baseUri, BlobServiceClient blobServiceClient, string container, string? feedSubPath = null, string? immutableCacheControl = null, string? mutableCacheControl = null)
             : base(cache, root, baseUri, feedSubPath)
         {
             _container = blobServiceClient.GetBlobContainerClient(container);
+            _immutableCacheControl = immutableCacheControl ?? "no-cache";
+            _mutableCacheControl = mutableCacheControl ?? "no-cache";
 
             var containerUri = UriUtility.EnsureTrailingSlash(_container.Uri);
             var expectedPath = UriUtility.EnsureTrailingSlash(root);
@@ -54,7 +58,9 @@ namespace Sleet
                     pair.Root,
                     pair.BaseURI,
                     LocalCache.GetNewTempPath(),
-                    _container.GetBlobClient(GetRelativePath(path))));
+                    _container.GetBlobClient(GetRelativePath(path)),
+                    _immutableCacheControl,
+                    _mutableCacheControl));
         }
 
         public override async Task<bool> Validate(ILogger log, CancellationToken token)

--- a/src/SleetLib/FileSystem/AzureFileSystem.cs
+++ b/src/SleetLib/FileSystem/AzureFileSystem.cs
@@ -21,8 +21,8 @@ namespace Sleet
             : base(cache, root, baseUri, feedSubPath)
         {
             _container = blobServiceClient.GetBlobContainerClient(container);
-            _immutableCacheControl = immutableCacheControl ?? "no-cache";
-            _mutableCacheControl = mutableCacheControl ?? "no-cache";
+            _immutableCacheControl = immutableCacheControl ?? "no-store";
+            _mutableCacheControl = mutableCacheControl ?? "no-store";
 
             var containerUri = UriUtility.EnsureTrailingSlash(_container.Uri);
             var expectedPath = UriUtility.EnsureTrailingSlash(root);

--- a/src/SleetLib/FileSystem/FileSystemFactory.cs
+++ b/src/SleetLib/FileSystem/FileSystemFactory.cs
@@ -111,8 +111,16 @@ namespace Sleet
                         var compress = JsonUtility.GetBoolCaseInsensitive(sourceEntry, "compress", true);
                         var acl = JsonUtility.GetValueCaseInsensitive(sourceEntry, "acl");
                         var disablePayloadSigning = JsonUtility.GetBoolCaseInsensitive(sourceEntry, "disablePayloadSigning", false);
-                        var immutableCacheControl = JsonUtility.GetValueCaseInsensitive(sourceEntry, "immutableCacheControl") ?? "no-store";
-                        var mutableCacheControl = JsonUtility.GetValueCaseInsensitive(sourceEntry, "mutableCacheControl") ?? "no-store";
+                        var immutableCacheControl = JsonUtility.GetValueCaseInsensitive(sourceEntry, "immutableCacheControl");
+                        if (string.IsNullOrWhiteSpace(immutableCacheControl))
+                        {
+                            immutableCacheControl = "no-store";
+                        }
+                        var mutableCacheControl = JsonUtility.GetValueCaseInsensitive(sourceEntry, "mutableCacheControl");
+                        if (string.IsNullOrWhiteSpace(mutableCacheControl))
+                        {
+                            mutableCacheControl = "no-store";
+                        }
 
 
                         if (string.IsNullOrEmpty(bucketName))

--- a/src/SleetLib/FileSystem/FileSystemFactory.cs
+++ b/src/SleetLib/FileSystem/FileSystemFactory.cs
@@ -79,8 +79,8 @@ namespace Sleet
                         var container = JsonUtility.GetValueCaseInsensitive(sourceEntry, "container");
                         var immutableCacheControlValue = JsonUtility.GetValueCaseInsensitive(sourceEntry, "immutableCacheControl");
                         var mutableCacheControlValue = JsonUtility.GetValueCaseInsensitive(sourceEntry, "mutableCacheControl");
-                        var immutableCacheControl = string.IsNullOrWhiteSpace(immutableCacheControlValue) ? "no-cache" : immutableCacheControlValue;
-                        var mutableCacheControl = string.IsNullOrWhiteSpace(mutableCacheControlValue) ? "no-cache" : mutableCacheControlValue;
+                        var immutableCacheControl = string.IsNullOrWhiteSpace(immutableCacheControlValue) ? "no-store" : immutableCacheControlValue;
+                        var mutableCacheControl = string.IsNullOrWhiteSpace(mutableCacheControlValue) ? "no-store" : mutableCacheControlValue;
 
                         if (string.IsNullOrEmpty(container))
                         {

--- a/src/SleetLib/FileSystem/FileSystemFactory.cs
+++ b/src/SleetLib/FileSystem/FileSystemFactory.cs
@@ -77,8 +77,10 @@ namespace Sleet
                     {
                         var connectionString = JsonUtility.GetValueCaseInsensitive(sourceEntry, "connectionString");
                         var container = JsonUtility.GetValueCaseInsensitive(sourceEntry, "container");
-                        var immutableCacheControl = JsonUtility.GetValueCaseInsensitive(sourceEntry, "immutableCacheControl") ?? "no-cache";
-                        var mutableCacheControl = JsonUtility.GetValueCaseInsensitive(sourceEntry, "mutableCacheControl") ?? "no-cache";
+                        var immutableCacheControlValue = JsonUtility.GetValueCaseInsensitive(sourceEntry, "immutableCacheControl");
+                        var mutableCacheControlValue = JsonUtility.GetValueCaseInsensitive(sourceEntry, "mutableCacheControl");
+                        var immutableCacheControl = string.IsNullOrWhiteSpace(immutableCacheControlValue) ? "no-cache" : immutableCacheControlValue;
+                        var mutableCacheControl = string.IsNullOrWhiteSpace(mutableCacheControlValue) ? "no-cache" : mutableCacheControlValue;
 
                         if (string.IsNullOrEmpty(container))
                         {

--- a/src/SleetLib/FileSystem/FileSystemFactory.cs
+++ b/src/SleetLib/FileSystem/FileSystemFactory.cs
@@ -111,8 +111,8 @@ namespace Sleet
                         var compress = JsonUtility.GetBoolCaseInsensitive(sourceEntry, "compress", true);
                         var acl = JsonUtility.GetValueCaseInsensitive(sourceEntry, "acl");
                         var disablePayloadSigning = JsonUtility.GetBoolCaseInsensitive(sourceEntry, "disablePayloadSigning", false);
-                        var immutableCacheControl = JsonUtility.GetValueCaseInsensitive(sourceEntry, "immutableCacheControl") ?? "no-cache";
-                        var mutableCacheControl = JsonUtility.GetValueCaseInsensitive(sourceEntry, "mutableCacheControl") ?? "no-cache";
+                        var immutableCacheControl = JsonUtility.GetValueCaseInsensitive(sourceEntry, "immutableCacheControl") ?? "no-store";
+                        var mutableCacheControl = JsonUtility.GetValueCaseInsensitive(sourceEntry, "mutableCacheControl") ?? "no-store";
 
 
                         if (string.IsNullOrEmpty(bucketName))

--- a/src/SleetLib/FileSystem/FileSystemFactory.cs
+++ b/src/SleetLib/FileSystem/FileSystemFactory.cs
@@ -77,6 +77,8 @@ namespace Sleet
                     {
                         var connectionString = JsonUtility.GetValueCaseInsensitive(sourceEntry, "connectionString");
                         var container = JsonUtility.GetValueCaseInsensitive(sourceEntry, "container");
+                        var immutableCacheControl = JsonUtility.GetValueCaseInsensitive(sourceEntry, "immutableCacheControl") ?? "no-cache";
+                        var mutableCacheControl = JsonUtility.GetValueCaseInsensitive(sourceEntry, "mutableCacheControl") ?? "no-cache";
 
                         if (string.IsNullOrEmpty(container))
                         {
@@ -93,7 +95,7 @@ namespace Sleet
 
                         baseUri ??= pathUri;
 
-                        result = new AzureFileSystem(cache, pathUri, baseUri, blobServiceClient, container, feedSubPath);
+                        result = new AzureFileSystem(cache, pathUri, baseUri, blobServiceClient, container, feedSubPath, immutableCacheControl, mutableCacheControl);
                     }
                     else if (type == "s3")
                     {
@@ -107,6 +109,8 @@ namespace Sleet
                         var compress = JsonUtility.GetBoolCaseInsensitive(sourceEntry, "compress", true);
                         var acl = JsonUtility.GetValueCaseInsensitive(sourceEntry, "acl");
                         var disablePayloadSigning = JsonUtility.GetBoolCaseInsensitive(sourceEntry, "disablePayloadSigning", false);
+                        var immutableCacheControl = JsonUtility.GetValueCaseInsensitive(sourceEntry, "immutableCacheControl") ?? "no-cache";
+                        var mutableCacheControl = JsonUtility.GetValueCaseInsensitive(sourceEntry, "mutableCacheControl") ?? "no-cache";
 
 
                         if (string.IsNullOrEmpty(bucketName))
@@ -245,7 +249,9 @@ namespace Sleet
                             feedSubPath,
                             compress,
                             resolvedAcl,
-                            disablePayloadSigning
+                            disablePayloadSigning,
+                            immutableCacheControl,
+                            mutableCacheControl
                         );
                     }
                 }

--- a/test/Sleet.AmazonS3.Tests/CacheControlTests.cs
+++ b/test/Sleet.AmazonS3.Tests/CacheControlTests.cs
@@ -3,6 +3,7 @@ using FluentAssertions;
 using Newtonsoft.Json.Linq;
 using NuGet.Test.Helpers;
 using Sleet.Test.Common;
+using System.Net.Http.Headers;
 using static Sleet.AmazonS3FileSystemAbstraction;
 
 namespace Sleet.AmazonS3.Tests
@@ -34,19 +35,19 @@ namespace Sleet.AmazonS3.Tests
                 var nupkgMetadata = await testContext.Client.GetObjectMetadataAsync(
                     testContext.BucketName,
                     "flatcontainer/packagea/1.0.0/packagea.1.0.0.nupkg");
-                nupkgMetadata.Headers.CacheControl.Should().Be("no-store");
+                CacheControlHeaderValue.Parse(nupkgMetadata.Headers.CacheControl).Should().Be(CacheControlHeaderValue.Parse("no-store"));
 
                 // Verify .nuspec has no-store
                 var nuspecMetadata = await testContext.Client.GetObjectMetadataAsync(
                     testContext.BucketName,
                     "flatcontainer/packagea/1.0.0/packagea.nuspec");
-                nuspecMetadata.Headers.CacheControl.Should().Be("no-store");
+                CacheControlHeaderValue.Parse(nuspecMetadata.Headers.CacheControl).Should().Be(CacheControlHeaderValue.Parse("no-store"));
 
                 // Verify index.json has no-store
                 var indexMetadata = await testContext.Client.GetObjectMetadataAsync(
                     testContext.BucketName,
                     "index.json");
-                indexMetadata.Headers.CacheControl.Should().Be("no-store");
+                CacheControlHeaderValue.Parse(indexMetadata.Headers.CacheControl).Should().Be(CacheControlHeaderValue.Parse("no-store"));
 
                 await testContext.CleanupAsync();
             }
@@ -104,25 +105,25 @@ namespace Sleet.AmazonS3.Tests
                 var nupkgMetadata = await testContext.Client.GetObjectMetadataAsync(
                     testContext.BucketName,
                     "flatcontainer/packageb/1.0.0/packageb.1.0.0.nupkg");
-                nupkgMetadata.Headers.CacheControl.Should().Be(immutableCacheControl);
+                CacheControlHeaderValue.Parse(nupkgMetadata.Headers.CacheControl).Should().Be(CacheControlHeaderValue.Parse(immutableCacheControl));
 
                 // Verify .nuspec has immutable cache control
                 var nuspecMetadata = await testContext.Client.GetObjectMetadataAsync(
                     testContext.BucketName,
                     "flatcontainer/packageb/1.0.0/packageb.nuspec");
-                nuspecMetadata.Headers.CacheControl.Should().Be(immutableCacheControl);
+                CacheControlHeaderValue.Parse(nuspecMetadata.Headers.CacheControl).Should().Be(CacheControlHeaderValue.Parse(immutableCacheControl));
 
                 // Verify index.json has mutable cache control
                 var indexMetadata = await testContext.Client.GetObjectMetadataAsync(
                     testContext.BucketName,
                     "index.json");
-                indexMetadata.Headers.CacheControl.Should().Be(mutableCacheControl);
+                CacheControlHeaderValue.Parse(indexMetadata.Headers.CacheControl).Should().Be(CacheControlHeaderValue.Parse(mutableCacheControl));
 
                 // Verify flatcontainer index.json has mutable cache control
                 var flatcontainerIndexMetadata = await testContext.Client.GetObjectMetadataAsync(
                     testContext.BucketName,
                     "flatcontainer/packageb/index.json");
-                flatcontainerIndexMetadata.Headers.CacheControl.Should().Be(mutableCacheControl);
+                CacheControlHeaderValue.Parse(flatcontainerIndexMetadata.Headers.CacheControl).Should().Be(CacheControlHeaderValue.Parse(mutableCacheControl));
 
                 await testContext.CleanupAsync();
             }
@@ -184,13 +185,13 @@ namespace Sleet.AmazonS3.Tests
                 var nupkgMetadata = await testContext.Client.GetObjectMetadataAsync(
                     testContext.BucketName,
                     "flatcontainer/packagec/2.0.0/packagec.2.0.0.nupkg");
-                nupkgMetadata.Headers.CacheControl.Should().Be(immutableCacheControl);
+                CacheControlHeaderValue.Parse(nupkgMetadata.Headers.CacheControl).Should().Be(CacheControlHeaderValue.Parse(immutableCacheControl));
 
                 // Verify index.json has mutable cache control
                 var indexMetadata = await testContext.Client.GetObjectMetadataAsync(
                     testContext.BucketName,
                     "index.json");
-                indexMetadata.Headers.CacheControl.Should().Be(mutableCacheControl);
+                CacheControlHeaderValue.Parse(indexMetadata.Headers.CacheControl).Should().Be(CacheControlHeaderValue.Parse(mutableCacheControl));
 
                 await testContext.CleanupAsync();
             }

--- a/test/Sleet.AmazonS3.Tests/CacheControlTests.cs
+++ b/test/Sleet.AmazonS3.Tests/CacheControlTests.cs
@@ -1,4 +1,3 @@
-using Amazon.S3.Model;
 using FluentAssertions;
 using Newtonsoft.Json.Linq;
 using NuGet.Test.Helpers;

--- a/test/Sleet.AmazonS3.Tests/CacheControlTests.cs
+++ b/test/Sleet.AmazonS3.Tests/CacheControlTests.cs
@@ -1,0 +1,199 @@
+using Amazon.S3.Model;
+using FluentAssertions;
+using Newtonsoft.Json.Linq;
+using NuGet.Test.Helpers;
+using Sleet.Test.Common;
+using static Sleet.AmazonS3FileSystemAbstraction;
+
+namespace Sleet.AmazonS3.Tests
+{
+    public class CacheControlTests
+    {
+        [EnvVarExistsFact(AmazonS3TestContext.EnvAccessKeyId)]
+        public async Task GivenDefaultSettings_VerifyCacheControlIsNoStore()
+        {
+            using (var packagesFolder = new TestFolder())
+            using (var testContext = new AmazonS3TestContext())
+            {
+                await testContext.InitAsync();
+
+                // Create a test package
+                var testPackage = new TestNupkg("packageA", "1.0.0");
+                var zipFile = testPackage.Save(packagesFolder.Root);
+
+                // Push package
+                await PushCommand.RunAsync(
+                    testContext.LocalSettings,
+                    testContext.FileSystem,
+                    new List<string> { zipFile.FullName },
+                    force: false,
+                    skipExisting: false,
+                    log: testContext.Logger);
+
+                // Verify .nupkg has no-store
+                var nupkgMetadata = await testContext.Client.GetObjectMetadataAsync(
+                    testContext.BucketName,
+                    "flatcontainer/packagea/1.0.0/packagea.1.0.0.nupkg");
+                nupkgMetadata.Headers.CacheControl.Should().Be("no-store");
+
+                // Verify .nuspec has no-store
+                var nuspecMetadata = await testContext.Client.GetObjectMetadataAsync(
+                    testContext.BucketName,
+                    "flatcontainer/packagea/1.0.0/packagea.nuspec");
+                nuspecMetadata.Headers.CacheControl.Should().Be("no-store");
+
+                // Verify index.json has no-store
+                var indexMetadata = await testContext.Client.GetObjectMetadataAsync(
+                    testContext.BucketName,
+                    "index.json");
+                indexMetadata.Headers.CacheControl.Should().Be("no-store");
+
+                await testContext.CleanupAsync();
+            }
+        }
+
+        [EnvVarExistsFact(AmazonS3TestContext.EnvAccessKeyId)]
+        public async Task GivenCustomCacheControl_VerifyHeadersAreSet()
+        {
+            using (var packagesFolder = new TestFolder())
+            using (var testContext = new AmazonS3TestContext())
+            {
+                await testContext.InitAsync();
+
+                var immutableCacheControl = "public, max-age=31536000, immutable";
+                var mutableCacheControl = "public, max-age=300, must-revalidate";
+
+                // Create file system with custom cache control
+                testContext.FileSystem = new AmazonS3FileSystem(
+                    testContext.LocalCache,
+                    testContext.Uri,
+                    testContext.Uri,
+                    testContext.Client,
+                    testContext.BucketName,
+                    Amazon.S3.ServerSideEncryptionMethod.None,
+                    feedSubPath: null,
+                    compress: true,
+                    acl: null,
+                    disablePayloadSigning: false,
+                    immutableCacheControl: immutableCacheControl,
+                    mutableCacheControl: mutableCacheControl);
+
+                // Initialize feed
+                await InitCommand.RunAsync(
+                    testContext.LocalSettings,
+                    testContext.FileSystem,
+                    enableCatalog: false,
+                    enableSymbols: false,
+                    log: testContext.Logger,
+                    token: CancellationToken.None);
+
+                // Create a test package
+                var testPackage = new TestNupkg("packageB", "1.0.0");
+                var zipFile = testPackage.Save(packagesFolder.Root);
+
+                // Push package
+                await PushCommand.RunAsync(
+                    testContext.LocalSettings,
+                    testContext.FileSystem,
+                    new List<string> { zipFile.FullName },
+                    force: false,
+                    skipExisting: false,
+                    log: testContext.Logger);
+
+                // Verify .nupkg has immutable cache control
+                var nupkgMetadata = await testContext.Client.GetObjectMetadataAsync(
+                    testContext.BucketName,
+                    "flatcontainer/packageb/1.0.0/packageb.1.0.0.nupkg");
+                nupkgMetadata.Headers.CacheControl.Should().Be(immutableCacheControl);
+
+                // Verify .nuspec has immutable cache control
+                var nuspecMetadata = await testContext.Client.GetObjectMetadataAsync(
+                    testContext.BucketName,
+                    "flatcontainer/packageb/1.0.0/packageb.nuspec");
+                nuspecMetadata.Headers.CacheControl.Should().Be(immutableCacheControl);
+
+                // Verify index.json has mutable cache control
+                var indexMetadata = await testContext.Client.GetObjectMetadataAsync(
+                    testContext.BucketName,
+                    "index.json");
+                indexMetadata.Headers.CacheControl.Should().Be(mutableCacheControl);
+
+                // Verify flatcontainer index.json has mutable cache control
+                var flatcontainerIndexMetadata = await testContext.Client.GetObjectMetadataAsync(
+                    testContext.BucketName,
+                    "flatcontainer/packageb/index.json");
+                flatcontainerIndexMetadata.Headers.CacheControl.Should().Be(mutableCacheControl);
+
+                await testContext.CleanupAsync();
+            }
+        }
+
+        [EnvVarExistsFact(AmazonS3TestContext.EnvAccessKeyId)]
+        public async Task GivenCustomCacheControlViaFactory_VerifyHeadersAreSet()
+        {
+            using (var packagesFolder = new TestFolder())
+            using (var testContext = new AmazonS3TestContext())
+            {
+                await testContext.InitAsync();
+
+                var immutableCacheControl = "public, max-age=604800";
+                var mutableCacheControl = "public, max-age=60";
+
+                var accessKeyId = Environment.GetEnvironmentVariable(AmazonS3TestContext.EnvAccessKeyId);
+                var secretAccessKey = Environment.GetEnvironmentVariable(AmazonS3TestContext.EnvSecretAccessKey);
+                var region = Environment.GetEnvironmentVariable(AmazonS3TestContext.EnvDefaultRegion) ?? "us-east-1";
+
+                var settings = LocalSettings.Load(new JObject(
+                    new JProperty("sources",
+                        new JArray(
+                            new JObject(
+                                new JProperty("name", "s3"),
+                                new JProperty("type", "s3"),
+                                new JProperty("bucketName", testContext.BucketName),
+                                new JProperty("region", region),
+                                new JProperty("accessKeyId", accessKeyId),
+                                new JProperty("secretAccessKey", secretAccessKey),
+                                new JProperty("immutableCacheControl", immutableCacheControl),
+                                new JProperty("mutableCacheControl", mutableCacheControl))))));
+
+                var fs = await FileSystemFactory.CreateFileSystemAsync(settings, testContext.LocalCache, "s3", testContext.Logger);
+
+                // Initialize feed
+                await InitCommand.RunAsync(
+                    settings,
+                    fs,
+                    enableCatalog: false,
+                    enableSymbols: false,
+                    log: testContext.Logger,
+                    token: CancellationToken.None);
+
+                // Create a test package
+                var testPackage = new TestNupkg("packageC", "2.0.0");
+                var zipFile = testPackage.Save(packagesFolder.Root);
+
+                // Push package
+                await PushCommand.RunAsync(
+                    settings,
+                    fs,
+                    new List<string> { zipFile.FullName },
+                    force: false,
+                    skipExisting: false,
+                    log: testContext.Logger);
+
+                // Verify .nupkg has immutable cache control
+                var nupkgMetadata = await testContext.Client.GetObjectMetadataAsync(
+                    testContext.BucketName,
+                    "flatcontainer/packagec/2.0.0/packagec.2.0.0.nupkg");
+                nupkgMetadata.Headers.CacheControl.Should().Be(immutableCacheControl);
+
+                // Verify index.json has mutable cache control
+                var indexMetadata = await testContext.Client.GetObjectMetadataAsync(
+                    testContext.BucketName,
+                    "index.json");
+                indexMetadata.Headers.CacheControl.Should().Be(mutableCacheControl);
+
+                await testContext.CleanupAsync();
+            }
+        }
+    }
+}

--- a/test/Sleet.AmazonS3.Tests/CacheControlTests.cs
+++ b/test/Sleet.AmazonS3.Tests/CacheControlTests.cs
@@ -3,7 +3,6 @@ using FluentAssertions;
 using Newtonsoft.Json.Linq;
 using NuGet.Test.Helpers;
 using Sleet.Test.Common;
-using static Sleet.AmazonS3FileSystemAbstraction;
 
 namespace Sleet.AmazonS3.Tests
 {

--- a/test/Sleet.Azure.Tests/CacheControlTests.cs
+++ b/test/Sleet.Azure.Tests/CacheControlTests.cs
@@ -1,0 +1,179 @@
+using Azure.Storage.Blobs.Models;
+using FluentAssertions;
+using Newtonsoft.Json.Linq;
+using NuGet.Test.Helpers;
+using Sleet.Test.Common;
+
+namespace Sleet.Azure.Tests
+{
+    public class CacheControlTests
+    {
+        [EnvVarExistsFact(AzureTestContext.EnvVarName)]
+        public async Task GivenDefaultSettings_VerifyCacheControlIsNoStore()
+        {
+            using (var packagesFolder = new TestFolder())
+            using (var testContext = new AzureTestContext())
+            {
+                await testContext.InitAsync();
+
+                // Create a test package
+                var testPackage = new TestNupkg("packageA", "1.0.0");
+                var zipFile = testPackage.Save(packagesFolder.Root);
+
+                // Push package
+                await PushCommand.RunAsync(
+                    testContext.LocalSettings,
+                    testContext.FileSystem,
+                    new List<string> { zipFile.FullName },
+                    force: false,
+                    skipExisting: false,
+                    log: testContext.Logger);
+
+                // Verify .nupkg has no-store
+                var nupkgBlob = testContext.Container.GetBlobClient("flatcontainer/packagea/1.0.0/packagea.1.0.0.nupkg");
+                var nupkgProperties = await nupkgBlob.GetPropertiesAsync();
+                nupkgProperties.Value.CacheControl.Should().Be("no-store");
+
+                // Verify .nuspec has no-store
+                var nuspecBlob = testContext.Container.GetBlobClient("flatcontainer/packagea/1.0.0/packagea.nuspec");
+                var nuspecProperties = await nuspecBlob.GetPropertiesAsync();
+                nuspecProperties.Value.CacheControl.Should().Be("no-store");
+
+                // Verify index.json has no-store
+                var indexBlob = testContext.Container.GetBlobClient("index.json");
+                var indexProperties = await indexBlob.GetPropertiesAsync();
+                indexProperties.Value.CacheControl.Should().Be("no-store");
+
+                await testContext.CleanupAsync();
+            }
+        }
+
+        [EnvVarExistsFact(AzureTestContext.EnvVarName)]
+        public async Task GivenCustomCacheControl_VerifyHeadersAreSet()
+        {
+            using (var packagesFolder = new TestFolder())
+            using (var testContext = new AzureTestContext())
+            {
+                await testContext.InitAsync();
+
+                var immutableCacheControl = "public, max-age=31536000, immutable";
+                var mutableCacheControl = "public, max-age=300, must-revalidate";
+
+                // Create file system with custom cache control
+                testContext.FileSystem = new AzureFileSystem(
+                    testContext.LocalCache,
+                    testContext.Uri,
+                    testContext.Uri,
+                    testContext.StorageAccount,
+                    testContext.ContainerName,
+                    feedSubPath: null,
+                    immutableCacheControl: immutableCacheControl,
+                    mutableCacheControl: mutableCacheControl);
+
+                // Initialize feed
+                await InitCommand.RunAsync(
+                    testContext.LocalSettings,
+                    testContext.FileSystem,
+                    enableCatalog: false,
+                    enableSymbols: false,
+                    log: testContext.Logger,
+                    token: CancellationToken.None);
+
+                // Create a test package
+                var testPackage = new TestNupkg("packageB", "1.0.0");
+                var zipFile = testPackage.Save(packagesFolder.Root);
+
+                // Push package
+                await PushCommand.RunAsync(
+                    testContext.LocalSettings,
+                    testContext.FileSystem,
+                    new List<string> { zipFile.FullName },
+                    force: false,
+                    skipExisting: false,
+                    log: testContext.Logger);
+
+                // Verify .nupkg has immutable cache control
+                var nupkgBlob = testContext.Container.GetBlobClient("flatcontainer/packageb/1.0.0/packageb.1.0.0.nupkg");
+                var nupkgProperties = await nupkgBlob.GetPropertiesAsync();
+                nupkgProperties.Value.CacheControl.Should().Be(immutableCacheControl);
+
+                // Verify .nuspec has immutable cache control
+                var nuspecBlob = testContext.Container.GetBlobClient("flatcontainer/packageb/1.0.0/packageb.nuspec");
+                var nuspecProperties = await nuspecBlob.GetPropertiesAsync();
+                nuspecProperties.Value.CacheControl.Should().Be(immutableCacheControl);
+
+                // Verify index.json has mutable cache control
+                var indexBlob = testContext.Container.GetBlobClient("index.json");
+                var indexProperties = await indexBlob.GetPropertiesAsync();
+                indexProperties.Value.CacheControl.Should().Be(mutableCacheControl);
+
+                // Verify flatcontainer index.json has mutable cache control
+                var flatcontainerIndexBlob = testContext.Container.GetBlobClient("flatcontainer/packageb/index.json");
+                var flatcontainerIndexProperties = await flatcontainerIndexBlob.GetPropertiesAsync();
+                flatcontainerIndexProperties.Value.CacheControl.Should().Be(mutableCacheControl);
+
+                await testContext.CleanupAsync();
+            }
+        }
+
+        [EnvVarExistsFact(AzureTestContext.EnvVarName)]
+        public async Task GivenCustomCacheControlViaFactory_VerifyHeadersAreSet()
+        {
+            using (var packagesFolder = new TestFolder())
+            using (var testContext = new AzureTestContext())
+            {
+                await testContext.InitAsync();
+
+                var immutableCacheControl = "public, max-age=604800";
+                var mutableCacheControl = "public, max-age=60";
+
+                var settings = LocalSettings.Load(new JObject(
+                    new JProperty("sources",
+                        new JArray(
+                            new JObject(
+                                new JProperty("name", "azure"),
+                                new JProperty("type", "azure"),
+                                new JProperty("container", testContext.ContainerName),
+                                new JProperty("connectionString", AzureTestContext.GetConnectionString()),
+                                new JProperty("immutableCacheControl", immutableCacheControl),
+                                new JProperty("mutableCacheControl", mutableCacheControl))))));
+
+                var fs = await FileSystemFactory.CreateFileSystemAsync(settings, testContext.LocalCache, "azure", testContext.Logger);
+
+                // Initialize feed
+                await InitCommand.RunAsync(
+                    settings,
+                    fs,
+                    enableCatalog: false,
+                    enableSymbols: false,
+                    log: testContext.Logger,
+                    token: CancellationToken.None);
+
+                // Create a test package
+                var testPackage = new TestNupkg("packageC", "2.0.0");
+                var zipFile = testPackage.Save(packagesFolder.Root);
+
+                // Push package
+                await PushCommand.RunAsync(
+                    settings,
+                    fs,
+                    new List<string> { zipFile.FullName },
+                    force: false,
+                    skipExisting: false,
+                    log: testContext.Logger);
+
+                // Verify .nupkg has immutable cache control
+                var nupkgBlob = testContext.Container.GetBlobClient("flatcontainer/packagec/2.0.0/packagec.2.0.0.nupkg");
+                var nupkgProperties = await nupkgBlob.GetPropertiesAsync();
+                nupkgProperties.Value.CacheControl.Should().Be(immutableCacheControl);
+
+                // Verify index.json has mutable cache control
+                var indexBlob = testContext.Container.GetBlobClient("index.json");
+                var indexProperties = await indexBlob.GetPropertiesAsync();
+                indexProperties.Value.CacheControl.Should().Be(mutableCacheControl);
+
+                await testContext.CleanupAsync();
+            }
+        }
+    }
+}

--- a/test/Sleet.Azure.Tests/CacheControlTests.cs
+++ b/test/Sleet.Azure.Tests/CacheControlTests.cs
@@ -1,4 +1,3 @@
-using Azure.Storage.Blobs.Models;
 using FluentAssertions;
 using Newtonsoft.Json.Linq;
 using NuGet.Test.Helpers;

--- a/test/Sleet.Azure.Tests/CacheControlTests.cs
+++ b/test/Sleet.Azure.Tests/CacheControlTests.cs
@@ -3,6 +3,7 @@ using FluentAssertions;
 using Newtonsoft.Json.Linq;
 using NuGet.Test.Helpers;
 using Sleet.Test.Common;
+using System.Net.Http.Headers;
 
 namespace Sleet.Azure.Tests
 {
@@ -32,17 +33,17 @@ namespace Sleet.Azure.Tests
                 // Verify .nupkg has no-store
                 var nupkgBlob = testContext.Container.GetBlobClient("flatcontainer/packagea/1.0.0/packagea.1.0.0.nupkg");
                 var nupkgProperties = await nupkgBlob.GetPropertiesAsync();
-                nupkgProperties.Value.CacheControl.Should().Be("no-store");
+                CacheControlHeaderValue.Parse(nupkgProperties.Value.CacheControl).Should().Be(CacheControlHeaderValue.Parse("no-store"));
 
                 // Verify .nuspec has no-store
                 var nuspecBlob = testContext.Container.GetBlobClient("flatcontainer/packagea/1.0.0/packagea.nuspec");
                 var nuspecProperties = await nuspecBlob.GetPropertiesAsync();
-                nuspecProperties.Value.CacheControl.Should().Be("no-store");
+                CacheControlHeaderValue.Parse(nuspecProperties.Value.CacheControl).Should().Be(CacheControlHeaderValue.Parse("no-store"));
 
                 // Verify index.json has no-store
                 var indexBlob = testContext.Container.GetBlobClient("index.json");
                 var indexProperties = await indexBlob.GetPropertiesAsync();
-                indexProperties.Value.CacheControl.Should().Be("no-store");
+                CacheControlHeaderValue.Parse(indexProperties.Value.CacheControl).Should().Be(CacheControlHeaderValue.Parse("no-store"));
 
                 await testContext.CleanupAsync();
             }
@@ -95,22 +96,22 @@ namespace Sleet.Azure.Tests
                 // Verify .nupkg has immutable cache control
                 var nupkgBlob = testContext.Container.GetBlobClient("flatcontainer/packageb/1.0.0/packageb.1.0.0.nupkg");
                 var nupkgProperties = await nupkgBlob.GetPropertiesAsync();
-                nupkgProperties.Value.CacheControl.Should().Be(immutableCacheControl);
+                CacheControlHeaderValue.Parse(nupkgProperties.Value.CacheControl).Should().Be(CacheControlHeaderValue.Parse(immutableCacheControl));
 
                 // Verify .nuspec has immutable cache control
                 var nuspecBlob = testContext.Container.GetBlobClient("flatcontainer/packageb/1.0.0/packageb.nuspec");
                 var nuspecProperties = await nuspecBlob.GetPropertiesAsync();
-                nuspecProperties.Value.CacheControl.Should().Be(immutableCacheControl);
+                CacheControlHeaderValue.Parse(nuspecProperties.Value.CacheControl).Should().Be(CacheControlHeaderValue.Parse(immutableCacheControl));
 
                 // Verify index.json has mutable cache control
                 var indexBlob = testContext.Container.GetBlobClient("index.json");
                 var indexProperties = await indexBlob.GetPropertiesAsync();
-                indexProperties.Value.CacheControl.Should().Be(mutableCacheControl);
+                CacheControlHeaderValue.Parse(indexProperties.Value.CacheControl).Should().Be(CacheControlHeaderValue.Parse(mutableCacheControl));
 
                 // Verify flatcontainer index.json has mutable cache control
                 var flatcontainerIndexBlob = testContext.Container.GetBlobClient("flatcontainer/packageb/index.json");
                 var flatcontainerIndexProperties = await flatcontainerIndexBlob.GetPropertiesAsync();
-                flatcontainerIndexProperties.Value.CacheControl.Should().Be(mutableCacheControl);
+                CacheControlHeaderValue.Parse(flatcontainerIndexProperties.Value.CacheControl).Should().Be(CacheControlHeaderValue.Parse(mutableCacheControl));
 
                 await testContext.CleanupAsync();
             }
@@ -165,12 +166,12 @@ namespace Sleet.Azure.Tests
                 // Verify .nupkg has immutable cache control
                 var nupkgBlob = testContext.Container.GetBlobClient("flatcontainer/packagec/2.0.0/packagec.2.0.0.nupkg");
                 var nupkgProperties = await nupkgBlob.GetPropertiesAsync();
-                nupkgProperties.Value.CacheControl.Should().Be(immutableCacheControl);
+                CacheControlHeaderValue.Parse(nupkgProperties.Value.CacheControl).Should().Be(CacheControlHeaderValue.Parse(immutableCacheControl));
 
                 // Verify index.json has mutable cache control
                 var indexBlob = testContext.Container.GetBlobClient("index.json");
                 var indexProperties = await indexBlob.GetPropertiesAsync();
-                indexProperties.Value.CacheControl.Should().Be(mutableCacheControl);
+                CacheControlHeaderValue.Parse(indexProperties.Value.CacheControl).Should().Be(CacheControlHeaderValue.Parse(mutableCacheControl));
 
                 await testContext.CleanupAsync();
             }


### PR DESCRIPTION
I opted in to implement cache configuration for files which are considered immutable - they are tied to a specific version (in their versioned folder) or a hash (pdbs) and files which are mutable (json and badges) so that we can have a little more control over how this is handled when the feed is proxied through a CDN to improve performance and optimize transfer costs.

Implemented it for both Azure and S3. The defaults are left as is - `no-store`.

Resolves #231