### PR TITLE
Add --verbosity option to control console output

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,9 @@
 name: Publish to NuGet.org
 
 on:
-  workflow_dispatch:   # ↩️ manual trigger only
+  release:
+    types: [published]   # 🚀 auto-publish when a GitHub Release is published
+  workflow_dispatch:      # ↩️ manual trigger fallback
 
 jobs:
   build-win:

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,7 +1,7 @@
 # Release Notes
 
 ## 7.2.0
-* Added `--verbosity <level>` option to control console output
+* Added `--verbosity <level>` (`-V`) option to control console output
 * Adjusted minimal verbosity to show the main actions and final result
 * Update NuGet.* packages to 7.6.0 to address advisory GHSA-g4vj-cjjj-v7hg
 

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,9 +1,7 @@
 # Release Notes
 
 ## 7.2.0
-* Added `--verbosity <level>` option to all commands to control console output: `quiet`, `minimal`, `normal`, `detailed`, or `diagnostic`
-  * Use `--verbosity minimal` (or `quiet`) to reduce push output to just a few lines when pushing packages one at a time
-  * `--verbose` is now an alias for `--verbosity detailed`
+* Added `--verbosity <level>` option to control console output
 * Update NuGet.* packages to 7.6.0 to address advisory GHSA-g4vj-cjjj-v7hg
 
 ## 7.1.1

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,6 +1,9 @@
 # Release Notes
 
 ## 7.2.0
+* Added `--verbosity <level>` option to all commands to control console output: `quiet`, `minimal`, `normal`, `detailed`, or `diagnostic`
+  * Use `--verbosity minimal` (or `quiet`) to reduce push output to just a few lines when pushing packages one at a time
+  * `--verbose` is now an alias for `--verbosity detailed`
 * Update NuGet.* packages to 7.6.0 to address advisory GHSA-g4vj-cjjj-v7hg
 
 ## 7.1.1

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -2,6 +2,7 @@
 
 ## 7.2.0
 * Added `--verbosity <level>` option to control console output
+* Adjusted minimal verbosity to show the main actions and final result
 * Update NuGet.* packages to 7.6.0 to address advisory GHSA-g4vj-cjjj-v7hg
 
 ## 7.1.1

--- a/doc/commands.md
+++ b/doc/commands.md
@@ -5,6 +5,22 @@ The help parameter may be applied to any command to see a description of all par
 
 ``sleet.exe --help``
 
+## Logging verbosity
+All commands accept ``--verbosity <level>`` to control how much console output is written. This is useful for tooling that pushes packages one at a time and wants only a couple of lines per operation.
+
+``sleet.exe push mypackage.nupkg --verbosity minimal``
+
+| Level | Description |
+| --- | ------ |
+| quiet | Only warnings and errors. |
+| minimal | Key progress and results without the performance summary. |
+| normal | Default output. |
+| detailed | Additional messages. Equivalent to ``--verbose``. |
+| diagnostic | Full debug output. |
+
+``--verbose`` remains available as an alias for ``--verbosity detailed``. When both are supplied, ``--verbosity`` wins.
+
+
 ## CreateConfig
 All commands require a *sleet.json* config file to provide source settings. Before creating a new source the *createconfig* command may be used to output a *sleet.json* template file that may be filled in with your own settings.
 
@@ -52,6 +68,7 @@ Push adds packages to your feed. It can be used to add individual packages or co
 | source | Source name from *sleet.json*. |
 | force | Overwrite existing packages. Defaults to *false* |
 | skip-existing | Skip packages that already exist on the feed. |
+| verbosity | Console log verbosity: *quiet*, *minimal*, *normal*, *detailed*, or *diagnostic*. See [Logging verbosity](#logging-verbosity). |
 
 ### Examples
 
@@ -62,6 +79,10 @@ Pushing a single nupkg
 Pushing multiple directories of nupkgs
 
 ``sleet push /my/nupkgs1/ /my/nupkgs2/ --source myFeed``
+
+Pushing a single nupkg with reduced output
+
+``sleet push path/to/mynupkg.nupkg --source myFeed --verbosity minimal``
 
 ## Delete
 

--- a/doc/commands.md
+++ b/doc/commands.md
@@ -307,7 +307,7 @@ All commands accept ``--verbosity <level>`` to control how much console output i
 | Level | Description |
 | --- | ------ |
 | quiet | Only warnings and errors. |
-| minimal | Key progress and results without the performance summary. |
+| minimal | The main actions taken and the final result. |
 | normal | Default output. |
 | detailed | Additional messages. |
 | diagnostic | Full debug output. |

--- a/doc/commands.md
+++ b/doc/commands.md
@@ -309,7 +309,5 @@ All commands accept ``--verbosity <level>`` to control how much console output i
 | quiet | Only warnings and errors. |
 | minimal | Key progress and results without the performance summary. |
 | normal | Default output. |
-| detailed | Additional messages. Equivalent to ``--verbose``. |
+| detailed | Additional messages. |
 | diagnostic | Full debug output. |
-
-``--verbose`` remains available as an alias for ``--verbosity detailed``. When both are supplied, ``--verbosity`` wins.

--- a/doc/commands.md
+++ b/doc/commands.md
@@ -5,22 +5,6 @@ The help parameter may be applied to any command to see a description of all par
 
 ``sleet.exe --help``
 
-## Logging verbosity
-All commands accept ``--verbosity <level>`` to control how much console output is written. This is useful for tooling that pushes packages one at a time and wants only a couple of lines per operation.
-
-``sleet.exe push mypackage.nupkg --verbosity minimal``
-
-| Level | Description |
-| --- | ------ |
-| quiet | Only warnings and errors. |
-| minimal | Key progress and results without the performance summary. |
-| normal | Default output. |
-| detailed | Additional messages. Equivalent to ``--verbose``. |
-| diagnostic | Full debug output. |
-
-``--verbose`` remains available as an alias for ``--verbosity detailed``. When both are supplied, ``--verbosity`` wins.
-
-
 ## CreateConfig
 All commands require a *sleet.json* config file to provide source settings. Before creating a new source the *createconfig* command may be used to output a *sleet.json* template file that may be filled in with your own settings.
 
@@ -314,3 +298,18 @@ and only the highest version will be left.
 All feed related commands allow passing *--property* to specify properties on the command line. These properties can be used to override env vars or populate tokens in sleet.json.
 
 For more information see [client settings](client-settings.md)
+
+## Logging verbosity
+All commands accept ``--verbosity <level>`` to control how much console output is written. This is useful for tooling that pushes packages one at a time and wants only a couple of lines per operation.
+
+``sleet.exe push mypackage.nupkg --verbosity minimal``
+
+| Level | Description |
+| --- | ------ |
+| quiet | Only warnings and errors. |
+| minimal | Key progress and results without the performance summary. |
+| normal | Default output. |
+| detailed | Additional messages. Equivalent to ``--verbose``. |
+| diagnostic | Full debug output. |
+
+``--verbose`` remains available as an alias for ``--verbosity detailed``. When both are supplied, ``--verbosity`` wins.

--- a/doc/commands.md
+++ b/doc/commands.md
@@ -300,7 +300,7 @@ All feed related commands allow passing *--property* to specify properties on th
 For more information see [client settings](client-settings.md)
 
 ## Logging verbosity
-All commands accept ``--verbosity <level>`` to control how much console output is written. This is useful for tooling that pushes packages one at a time and wants only a couple of lines per operation.
+All commands accept ``--verbosity <level>`` (short form ``-V``) to control how much console output is written. This is useful for tooling that pushes packages one at a time and wants only a couple of lines per operation.
 
 ``sleet.exe push mypackage.nupkg --verbosity minimal``
 

--- a/src/Sleet/Constants.cs
+++ b/src/Sleet/Constants.cs
@@ -8,7 +8,9 @@ namespace Sleet
         internal const string SourceOption = "-s|--source";
         internal const string SourceDesc = "Source name from sleet.json.";
         internal const string VerboseOption = "--verbose";
-        internal const string VerboseDesc = "Write out additional messages for verbose output.";
+        internal const string VerboseDesc = "Write out additional messages for verbose output. Alias for --verbosity detailed.";
+        internal const string VerbosityOption = "--verbosity";
+        internal const string VerbosityDesc = "Set the log verbosity: quiet, minimal, normal, detailed, or diagnostic. Defaults to normal.";
         internal const string EnableCatalogOption = "--with-catalog";
         internal const string EnableCatalogDesc = "Enable the feed catalog and all change history tracking.";
         internal const string EnableSymbolsFeedOption = "--with-symbols";

--- a/src/Sleet/Constants.cs
+++ b/src/Sleet/Constants.cs
@@ -9,7 +9,7 @@ namespace Sleet
         internal const string SourceDesc = "Source name from sleet.json.";
         internal const string VerboseOption = "--verbose";
         internal const string VerboseDesc = "Write out additional messages for verbose output. Alias for --verbosity detailed.";
-        internal const string VerbosityOption = "--verbosity";
+        internal const string VerbosityOption = "-V|--verbosity";
         internal const string VerbosityDesc = "Set the log verbosity: quiet, minimal, normal, detailed, or diagnostic. Defaults to normal.";
         internal const string EnableCatalogOption = "--with-catalog";
         internal const string EnableCatalogDesc = "Enable the feed catalog and all change history tracking.";

--- a/src/Sleet/CreateConfigAppCommand.cs
+++ b/src/Sleet/CreateConfigAppCommand.cs
@@ -27,6 +27,7 @@ namespace Sleet
                 CommandOptionType.SingleValue);
 
             var verbose = cmd.Option(Constants.VerboseOption, Constants.VerboseDesc, CommandOptionType.NoValue);
+            verbose.ShowInHelpText = false;
             var verbosity = cmd.Option(Constants.VerbosityOption, Constants.VerbosityDesc, CommandOptionType.SingleValue);
 
             cmd.HelpOption(Constants.HelpOption);

--- a/src/Sleet/CreateConfigAppCommand.cs
+++ b/src/Sleet/CreateConfigAppCommand.cs
@@ -27,13 +27,14 @@ namespace Sleet
                 CommandOptionType.SingleValue);
 
             var verbose = cmd.Option(Constants.VerboseOption, Constants.VerboseDesc, CommandOptionType.NoValue);
+            var verbosity = cmd.Option(Constants.VerbosityOption, Constants.VerbosityDesc, CommandOptionType.SingleValue);
 
             cmd.HelpOption(Constants.HelpOption);
 
             cmd.OnExecuteAsync(async _ =>
             {
                 // Init logger
-                Util.SetVerbosity(log, verbose.HasValue());
+                Util.SetVerbosity(log, verbose.HasValue(), verbosity.Value());
 
                 var outputPath = output.HasValue() ? output.Value() : null;
 

--- a/src/Sleet/DeleteAppCommand.cs
+++ b/src/Sleet/DeleteAppCommand.cs
@@ -32,6 +32,7 @@ namespace Sleet
             var force = cmd.Option("-f|--force", "Ignore missing packages.", CommandOptionType.NoValue);
 
             var verbose = cmd.Option(Constants.VerboseOption, Constants.VerboseDesc, CommandOptionType.NoValue);
+            var verbosity = cmd.Option(Constants.VerbosityOption, Constants.VerbosityDesc, CommandOptionType.SingleValue);
             var propertyOptions = cmd.Option(Constants.PropertyOption, Constants.PropertyDescription, CommandOptionType.MultipleValue);
 
             cmd.HelpOption(Constants.HelpOption);
@@ -47,7 +48,7 @@ namespace Sleet
                 CmdUtils.VerifyRequiredOptions(required.ToArray());
 
                 // Init logger
-                Util.SetVerbosity(log, verbose.HasValue());
+                Util.SetVerbosity(log, verbose.HasValue(), verbosity.Value());
 
                 // Create a temporary folder for caching files during the operation.
                 using (var cache = new LocalCache(new PerfTracker()))

--- a/src/Sleet/DeleteAppCommand.cs
+++ b/src/Sleet/DeleteAppCommand.cs
@@ -32,6 +32,7 @@ namespace Sleet
             var force = cmd.Option("-f|--force", "Ignore missing packages.", CommandOptionType.NoValue);
 
             var verbose = cmd.Option(Constants.VerboseOption, Constants.VerboseDesc, CommandOptionType.NoValue);
+            verbose.ShowInHelpText = false;
             var verbosity = cmd.Option(Constants.VerbosityOption, Constants.VerbosityDesc, CommandOptionType.SingleValue);
             var propertyOptions = cmd.Option(Constants.PropertyOption, Constants.PropertyDescription, CommandOptionType.MultipleValue);
 

--- a/src/Sleet/DestroyAppCommand.cs
+++ b/src/Sleet/DestroyAppCommand.cs
@@ -22,6 +22,7 @@ namespace Sleet
                 CommandOptionType.SingleValue);
 
             var verbose = cmd.Option(Constants.VerboseOption, Constants.VerboseDesc, CommandOptionType.NoValue);
+            verbose.ShowInHelpText = false;
             var verbosity = cmd.Option(Constants.VerbosityOption, Constants.VerbosityDesc, CommandOptionType.SingleValue);
             var propertyOptions = cmd.Option(Constants.PropertyOption, Constants.PropertyDescription, CommandOptionType.MultipleValue);
 

--- a/src/Sleet/DestroyAppCommand.cs
+++ b/src/Sleet/DestroyAppCommand.cs
@@ -22,6 +22,7 @@ namespace Sleet
                 CommandOptionType.SingleValue);
 
             var verbose = cmd.Option(Constants.VerboseOption, Constants.VerboseDesc, CommandOptionType.NoValue);
+            var verbosity = cmd.Option(Constants.VerbosityOption, Constants.VerbosityDesc, CommandOptionType.SingleValue);
             var propertyOptions = cmd.Option(Constants.PropertyOption, Constants.PropertyDescription, CommandOptionType.MultipleValue);
 
             cmd.HelpOption(Constants.HelpOption);
@@ -29,7 +30,7 @@ namespace Sleet
             cmd.OnExecuteAsync(async _ =>
             {
                 // Init logger
-                Util.SetVerbosity(log, verbose.HasValue());
+                Util.SetVerbosity(log, verbose.HasValue(), verbosity.Value());
 
                 // Create a temporary folder for caching files during the operation.
                 using (var cache = new LocalCache())

--- a/src/Sleet/DownloadAppCommand.cs
+++ b/src/Sleet/DownloadAppCommand.cs
@@ -22,6 +22,7 @@ namespace Sleet
                 CommandOptionType.SingleValue);
 
             var verbose = cmd.Option(Constants.VerboseOption, Constants.VerboseDesc, CommandOptionType.NoValue);
+            verbose.ShowInHelpText = false;
             var verbosity = cmd.Option(Constants.VerbosityOption, Constants.VerbosityDesc, CommandOptionType.SingleValue);
             var propertyOptions = cmd.Option(Constants.PropertyOption, Constants.PropertyDescription, CommandOptionType.MultipleValue);
 

--- a/src/Sleet/DownloadAppCommand.cs
+++ b/src/Sleet/DownloadAppCommand.cs
@@ -22,6 +22,7 @@ namespace Sleet
                 CommandOptionType.SingleValue);
 
             var verbose = cmd.Option(Constants.VerboseOption, Constants.VerboseDesc, CommandOptionType.NoValue);
+            var verbosity = cmd.Option(Constants.VerbosityOption, Constants.VerbosityDesc, CommandOptionType.SingleValue);
             var propertyOptions = cmd.Option(Constants.PropertyOption, Constants.PropertyDescription, CommandOptionType.MultipleValue);
 
             cmd.HelpOption(Constants.HelpOption);
@@ -42,7 +43,7 @@ namespace Sleet
                 CmdUtils.VerifyRequiredOptions(required.ToArray());
 
                 // Init logger
-                Util.SetVerbosity(log, verbose.HasValue());
+                Util.SetVerbosity(log, verbose.HasValue(), verbosity.Value());
 
                 // Create a temporary folder for caching files during the operation.
                 using (var cache = new LocalCache())

--- a/src/Sleet/FeedSettingsAppCommand.cs
+++ b/src/Sleet/FeedSettingsAppCommand.cs
@@ -23,6 +23,7 @@ namespace Sleet
                 CommandOptionType.SingleValue);
 
             var verbose = cmd.Option(Constants.VerboseOption, Constants.VerboseDesc, CommandOptionType.NoValue);
+            var verbosity = cmd.Option(Constants.VerbosityOption, Constants.VerbosityDesc, CommandOptionType.SingleValue);
 
             cmd.HelpOption(Constants.HelpOption);
 
@@ -41,7 +42,7 @@ namespace Sleet
                 CmdUtils.VerifyRequiredOptions(required.ToArray());
 
                 // Init logger
-                Util.SetVerbosity(log, verbose.HasValue());
+                Util.SetVerbosity(log, verbose.HasValue(), verbosity.Value());
 
                 // Create a temporary folder for caching files during the operation.
                 using (var cache = new LocalCache())

--- a/src/Sleet/FeedSettingsAppCommand.cs
+++ b/src/Sleet/FeedSettingsAppCommand.cs
@@ -23,6 +23,7 @@ namespace Sleet
                 CommandOptionType.SingleValue);
 
             var verbose = cmd.Option(Constants.VerboseOption, Constants.VerboseDesc, CommandOptionType.NoValue);
+            verbose.ShowInHelpText = false;
             var verbosity = cmd.Option(Constants.VerbosityOption, Constants.VerbosityDesc, CommandOptionType.SingleValue);
 
             cmd.HelpOption(Constants.HelpOption);

--- a/src/Sleet/InitAppCommand.cs
+++ b/src/Sleet/InitAppCommand.cs
@@ -24,6 +24,7 @@ namespace Sleet
                 CommandOptionType.SingleValue);
 
             var verbose = cmd.Option(Constants.VerboseOption, Constants.VerboseDesc, CommandOptionType.NoValue);
+            var verbosity = cmd.Option(Constants.VerbosityOption, Constants.VerbosityDesc, CommandOptionType.SingleValue);
 
             cmd.HelpOption(Constants.HelpOption);
 
@@ -39,7 +40,7 @@ namespace Sleet
                 CmdUtils.VerifyRequiredOptions(required.ToArray());
 
                 // Init logger
-                Util.SetVerbosity(log, verbose.HasValue());
+                Util.SetVerbosity(log, verbose.HasValue(), verbosity.Value());
 
                 // Create a temporary folder for caching files during the operation.
                 using (var cache = new LocalCache())

--- a/src/Sleet/InitAppCommand.cs
+++ b/src/Sleet/InitAppCommand.cs
@@ -24,6 +24,7 @@ namespace Sleet
                 CommandOptionType.SingleValue);
 
             var verbose = cmd.Option(Constants.VerboseOption, Constants.VerboseDesc, CommandOptionType.NoValue);
+            verbose.ShowInHelpText = false;
             var verbosity = cmd.Option(Constants.VerbosityOption, Constants.VerbosityDesc, CommandOptionType.SingleValue);
 
             cmd.HelpOption(Constants.HelpOption);

--- a/src/Sleet/PushAppCommand.cs
+++ b/src/Sleet/PushAppCommand.cs
@@ -29,6 +29,7 @@ namespace Sleet
                 CommandOptionType.SingleValue);
 
             var verbose = cmd.Option(Constants.VerboseOption, Constants.VerboseDesc, CommandOptionType.NoValue);
+            verbose.ShowInHelpText = false;
             var verbosity = cmd.Option(Constants.VerbosityOption, Constants.VerbosityDesc, CommandOptionType.SingleValue);
 
             var forceName = cmd.Option("-f|--force", "Overwrite existing packages.",

--- a/src/Sleet/PushAppCommand.cs
+++ b/src/Sleet/PushAppCommand.cs
@@ -29,6 +29,7 @@ namespace Sleet
                 CommandOptionType.SingleValue);
 
             var verbose = cmd.Option(Constants.VerboseOption, Constants.VerboseDesc, CommandOptionType.NoValue);
+            var verbosity = cmd.Option(Constants.VerbosityOption, Constants.VerbosityDesc, CommandOptionType.SingleValue);
 
             var forceName = cmd.Option("-f|--force", "Overwrite existing packages.",
                             CommandOptionType.NoValue);
@@ -51,7 +52,7 @@ namespace Sleet
                 CmdUtils.VerifyRequiredOptions(required.ToArray());
 
                 // Init logger
-                Util.SetVerbosity(log, verbose.HasValue());
+                Util.SetVerbosity(log, verbose.HasValue(), verbosity.Value());
 
                 // Create a temporary folder for caching files during the operation.
                 using (var cache = new LocalCache(new PerfTracker()))

--- a/src/Sleet/RecreateAppCommand.cs
+++ b/src/Sleet/RecreateAppCommand.cs
@@ -22,6 +22,7 @@ namespace Sleet
                 CommandOptionType.SingleValue);
 
             var verbose = cmd.Option(Constants.VerboseOption, Constants.VerboseDesc, CommandOptionType.NoValue);
+            verbose.ShowInHelpText = false;
             var verbosity = cmd.Option(Constants.VerbosityOption, Constants.VerbosityDesc, CommandOptionType.SingleValue);
 
             cmd.HelpOption(Constants.HelpOption);

--- a/src/Sleet/RecreateAppCommand.cs
+++ b/src/Sleet/RecreateAppCommand.cs
@@ -22,6 +22,7 @@ namespace Sleet
                 CommandOptionType.SingleValue);
 
             var verbose = cmd.Option(Constants.VerboseOption, Constants.VerboseDesc, CommandOptionType.NoValue);
+            var verbosity = cmd.Option(Constants.VerbosityOption, Constants.VerbosityDesc, CommandOptionType.SingleValue);
 
             cmd.HelpOption(Constants.HelpOption);
 
@@ -38,7 +39,7 @@ namespace Sleet
                 CmdUtils.VerifyRequiredOptions(required.ToArray());
 
                 // Init logger
-                Util.SetVerbosity(log, verbose.HasValue());
+                Util.SetVerbosity(log, verbose.HasValue(), verbosity.Value());
 
                 // Create a temporary folder for caching files during the operation.
                 using (var cache = new LocalCache())

--- a/src/Sleet/RetentionPruneAppCommand.cs
+++ b/src/Sleet/RetentionPruneAppCommand.cs
@@ -23,6 +23,7 @@ namespace Sleet
                 CommandOptionType.SingleValue);
 
             var verbose = cmd.Option(Constants.VerboseOption, Constants.VerboseDesc, CommandOptionType.NoValue);
+            var verbosity = cmd.Option(Constants.VerbosityOption, Constants.VerbosityDesc, CommandOptionType.SingleValue);
 
             cmd.HelpOption(Constants.HelpOption);
 
@@ -41,7 +42,7 @@ namespace Sleet
                 CmdUtils.VerifyRequiredOptions(required.ToArray());
 
                 // Init logger
-                Util.SetVerbosity(log, verbose.HasValue());
+                Util.SetVerbosity(log, verbose.HasValue(), verbosity.Value());
 
                 // Create a temporary folder for caching files during the operation.
                 using (var cache = new LocalCache())

--- a/src/Sleet/RetentionPruneAppCommand.cs
+++ b/src/Sleet/RetentionPruneAppCommand.cs
@@ -23,6 +23,7 @@ namespace Sleet
                 CommandOptionType.SingleValue);
 
             var verbose = cmd.Option(Constants.VerboseOption, Constants.VerboseDesc, CommandOptionType.NoValue);
+            verbose.ShowInHelpText = false;
             var verbosity = cmd.Option(Constants.VerbosityOption, Constants.VerbosityDesc, CommandOptionType.SingleValue);
 
             cmd.HelpOption(Constants.HelpOption);

--- a/src/Sleet/RetentionSettingsAppCommand.cs
+++ b/src/Sleet/RetentionSettingsAppCommand.cs
@@ -23,6 +23,7 @@ namespace Sleet
                 CommandOptionType.SingleValue);
 
             var verbose = cmd.Option(Constants.VerboseOption, Constants.VerboseDesc, CommandOptionType.NoValue);
+            var verbosity = cmd.Option(Constants.VerbosityOption, Constants.VerbosityDesc, CommandOptionType.SingleValue);
 
             cmd.HelpOption(Constants.HelpOption);
 
@@ -47,7 +48,7 @@ namespace Sleet
                 }
 
                 // Init logger
-                Util.SetVerbosity(log, verbose.HasValue());
+                Util.SetVerbosity(log, verbose.HasValue(), verbosity.Value());
 
                 // Create a temporary folder for caching files during the operation.
                 using (var cache = new LocalCache())

--- a/src/Sleet/RetentionSettingsAppCommand.cs
+++ b/src/Sleet/RetentionSettingsAppCommand.cs
@@ -23,6 +23,7 @@ namespace Sleet
                 CommandOptionType.SingleValue);
 
             var verbose = cmd.Option(Constants.VerboseOption, Constants.VerboseDesc, CommandOptionType.NoValue);
+            verbose.ShowInHelpText = false;
             var verbosity = cmd.Option(Constants.VerbosityOption, Constants.VerbosityDesc, CommandOptionType.SingleValue);
 
             cmd.HelpOption(Constants.HelpOption);

--- a/src/Sleet/StatsAppCommand.cs
+++ b/src/Sleet/StatsAppCommand.cs
@@ -23,6 +23,7 @@ namespace Sleet
                 CommandOptionType.SingleValue);
 
             var verbose = cmd.Option(Constants.VerboseOption, Constants.VerboseDesc, CommandOptionType.NoValue);
+            verbose.ShowInHelpText = false;
             var verbosity = cmd.Option(Constants.VerbosityOption, Constants.VerbosityDesc, CommandOptionType.SingleValue);
             var propertyOptions = cmd.Option(Constants.PropertyOption, Constants.PropertyDescription, CommandOptionType.MultipleValue);
 

--- a/src/Sleet/StatsAppCommand.cs
+++ b/src/Sleet/StatsAppCommand.cs
@@ -23,6 +23,7 @@ namespace Sleet
                 CommandOptionType.SingleValue);
 
             var verbose = cmd.Option(Constants.VerboseOption, Constants.VerboseDesc, CommandOptionType.NoValue);
+            var verbosity = cmd.Option(Constants.VerbosityOption, Constants.VerbosityDesc, CommandOptionType.SingleValue);
             var propertyOptions = cmd.Option(Constants.PropertyOption, Constants.PropertyDescription, CommandOptionType.MultipleValue);
 
             cmd.HelpOption(Constants.HelpOption);
@@ -35,7 +36,7 @@ namespace Sleet
                 CmdUtils.VerifyRequiredOptions(required.ToArray());
 
                 // Init logger
-                Util.SetVerbosity(log, verbose.HasValue());
+                Util.SetVerbosity(log, verbose.HasValue(), verbosity.Value());
 
                 // Create a temporary folder for caching files during the operation.
                 using (var cache = new LocalCache())

--- a/src/Sleet/Util.cs
+++ b/src/Sleet/Util.cs
@@ -93,23 +93,35 @@ namespace Sleet
             return results;
         }
 
-        internal static void SetVerbosity(ILogger log, bool verbose)
+        internal static void SetVerbosity(ILogger log, bool verbose, string? verbosity)
         {
             if (log is ConsoleLogger consoleLogger)
             {
+                LogLevel level;
+
                 if (CmdUtils.IsDebugModeEnabled())
                 {
-                    consoleLogger.VerbosityLevel = LogLevel.Debug;
+                    // The debug environment variable forces full diagnostic output.
+                    level = LogLevel.Debug;
+                }
+                else if (!string.IsNullOrEmpty(verbosity))
+                {
+                    // An explicit --verbosity value takes precedence over the --verbose alias.
+                    level = VerbosityUtility.GetLogLevel(verbosity!);
                 }
                 else if (verbose)
                 {
-                    consoleLogger.VerbosityLevel = LogLevel.Verbose;
+                    level = LogLevel.Verbose;
                 }
                 else
                 {
-                    consoleLogger.VerbosityLevel = DefaultLogLevel;
-                    consoleLogger.CollapseMessages = true;
+                    level = DefaultLogLevel;
                 }
+
+                consoleLogger.VerbosityLevel = level;
+
+                // Collapse extra messages when not showing verbose or debug output.
+                consoleLogger.CollapseMessages = level > LogLevel.Verbose;
             }
         }
     }

--- a/src/Sleet/Util.cs
+++ b/src/Sleet/Util.cs
@@ -104,10 +104,11 @@ namespace Sleet
                     // The debug environment variable forces full diagnostic output.
                     level = LogLevel.Debug;
                 }
-                else if (!string.IsNullOrEmpty(verbosity))
+                else if (verbosity != null)
                 {
                     // An explicit --verbosity value takes precedence over the --verbose alias.
-                    level = VerbosityUtility.GetLogLevel(verbosity!);
+                    // A supplied but empty value is treated as invalid rather than defaulting.
+                    level = VerbosityUtility.GetLogLevel(verbosity);
                 }
                 else if (verbose)
                 {

--- a/src/Sleet/ValidateAppCommand.cs
+++ b/src/Sleet/ValidateAppCommand.cs
@@ -23,6 +23,7 @@ namespace Sleet
                 CommandOptionType.SingleValue);
 
             var verbose = cmd.Option(Constants.VerboseOption, Constants.VerboseDesc, CommandOptionType.NoValue);
+            verbose.ShowInHelpText = false;
             var verbosity = cmd.Option(Constants.VerbosityOption, Constants.VerbosityDesc, CommandOptionType.SingleValue);
             var propertyOptions = cmd.Option(Constants.PropertyOption, Constants.PropertyDescription, CommandOptionType.MultipleValue);
 

--- a/src/Sleet/ValidateAppCommand.cs
+++ b/src/Sleet/ValidateAppCommand.cs
@@ -23,6 +23,7 @@ namespace Sleet
                 CommandOptionType.SingleValue);
 
             var verbose = cmd.Option(Constants.VerboseOption, Constants.VerboseDesc, CommandOptionType.NoValue);
+            var verbosity = cmd.Option(Constants.VerbosityOption, Constants.VerbosityDesc, CommandOptionType.SingleValue);
             var propertyOptions = cmd.Option(Constants.PropertyOption, Constants.PropertyDescription, CommandOptionType.MultipleValue);
 
             cmd.HelpOption(Constants.HelpOption);
@@ -35,7 +36,7 @@ namespace Sleet
                 CmdUtils.VerifyRequiredOptions(required.ToArray());
 
                 // Init logger
-                Util.SetVerbosity(log, verbose.HasValue());
+                Util.SetVerbosity(log, verbose.HasValue(), verbosity.Value());
 
                 // Create a temporary folder for caching files during the operation.
                 using (var cache = new LocalCache())

--- a/src/SleetLib/Commands/DeleteCommand.cs
+++ b/src/SleetLib/Commands/DeleteCommand.cs
@@ -21,7 +21,7 @@ namespace Sleet
 
             var token = CancellationToken.None;
 
-            log.LogMinimal($"Reading feed {source.BaseURI.AbsoluteUri}");
+            log.LogInformation($"Reading feed {source.BaseURI.AbsoluteUri}");
 
             // Check if already initialized
             using (var feedLock = await SourceUtility.VerifyInitAndLock(settings, source, "Delete", log, token))
@@ -69,7 +69,7 @@ namespace Sleet
                 await RemovePackages(force, log, context, existingPackageSets, packages);
 
                 // Save all
-                log.LogMinimal($"Committing changes to {source.BaseURI.AbsoluteUri}");
+                log.LogInformation($"Committing changes to {source.BaseURI.AbsoluteUri}");
 
                 success &= await source.Commit(log, token);
             }
@@ -95,7 +95,7 @@ namespace Sleet
 
             var token = CancellationToken.None;
 
-            log.LogMinimal($"Reading feed {source.BaseURI.AbsoluteUri}");
+            log.LogInformation($"Reading feed {source.BaseURI.AbsoluteUri}");
 
             // Check if already initialized
             using (var feedLock = await SourceUtility.VerifyInitAndLock(settings, source, "Delete", log, token))
@@ -129,7 +129,7 @@ namespace Sleet
                 await RemovePackages(force, log, context, existingPackageSets, packages);
 
                 // Save all
-                log.LogMinimal($"Committing changes to {source.BaseURI.AbsoluteUri}");
+                log.LogInformation($"Committing changes to {source.BaseURI.AbsoluteUri}");
 
                 success &= await source.Commit(log, token);
             }
@@ -192,7 +192,7 @@ namespace Sleet
                     message = $"Removing symbols package {package.ToString()}";
                 }
 
-                await log.LogAsync(LogLevel.Information, message);
+                await log.LogAsync(LogLevel.Minimal, message);
             }
 
             // Update feed

--- a/src/SleetLib/Commands/DestroyCommand.cs
+++ b/src/SleetLib/Commands/DestroyCommand.cs
@@ -25,7 +25,7 @@ namespace Sleet
         /// </summary>
         public static async Task<bool> Destroy(LocalSettings settings, ISleetFileSystem source, ILogger log, CancellationToken token)
         {
-            log.LogMinimal($"Reading feed {source.BaseURI.AbsoluteUri}");
+            log.LogInformation($"Reading feed {source.BaseURI.AbsoluteUri}");
 
             var success = await source.Destroy(log, token);
 

--- a/src/SleetLib/Commands/DownloadCommand.cs
+++ b/src/SleetLib/Commands/DownloadCommand.cs
@@ -89,7 +89,7 @@ namespace Sleet
                 Token = token
             };
 
-            log.LogMinimal($"Reading feed {source.BaseURI.AbsoluteUri}");
+            log.LogInformation($"Reading feed {source.BaseURI.AbsoluteUri}");
 
             // Find all packages
             var packageIndex = new PackageIndex(context);

--- a/src/SleetLib/Commands/FeedSettingsCommand.cs
+++ b/src/SleetLib/Commands/FeedSettingsCommand.cs
@@ -28,7 +28,7 @@ namespace Sleet
             ILogger log,
             CancellationToken token)
         {
-            log.LogMinimal($"Reading feed {source.BaseURI.AbsoluteUri}");
+            log.LogInformation($"Reading feed {source.BaseURI.AbsoluteUri}");
 
             // Check if already initialized
             using (var feedLock = await SourceUtility.VerifyInitAndLock(settings, source, "Feed settings", log, token))
@@ -170,7 +170,7 @@ namespace Sleet
                 await feedSettings.Write(feedSettingsJson, log, token);
 
                 // Save all
-                log.LogMinimal($"Committing changes to {source.BaseURI.AbsoluteUri}");
+                log.LogInformation($"Committing changes to {source.BaseURI.AbsoluteUri}");
 
                 return await source.Commit(log, token);
             }

--- a/src/SleetLib/Commands/PushCommand.cs
+++ b/src/SleetLib/Commands/PushCommand.cs
@@ -19,7 +19,7 @@ namespace Sleet
             var success = false;
             var perfTracker = source.LocalCache.PerfTracker;
 
-            await log.LogAsync(LogLevel.Minimal, $"Reading feed {source.BaseURI.AbsoluteUri}");
+            await log.LogAsync(LogLevel.Information, $"Reading feed {source.BaseURI.AbsoluteUri}");
 
             using (var timer = PerfEntryWrapper.CreateSummaryTimer("Total execution time: {0}", perfTracker))
             {
@@ -113,7 +113,7 @@ namespace Sleet
             CheckForDuplicates(packages);
 
             // Get sleet.settings.json
-            await log.LogAsync(LogLevel.Minimal, "Reading feed");
+            await log.LogAsync(LogLevel.Information, "Reading feed");
             var sourceSettings = await FeedSettingsUtility.GetSettingsOrDefault(source, log, token);
 
             // Settings context used for all operations
@@ -139,7 +139,7 @@ namespace Sleet
             await PrunePackages(packages, context);
 
             // Save all
-            await log.LogAsync(LogLevel.Minimal, $"Committing changes to {source.BaseURI.AbsoluteUri}");
+            await log.LogAsync(LogLevel.Information, $"Committing changes to {source.BaseURI.AbsoluteUri}");
 
             await source.Commit(log, token);
 
@@ -214,7 +214,7 @@ namespace Sleet
                     else if (force)
                     {
                         toRemove.Add(package);
-                        await log.LogAsync(LogLevel.Information, $"Replace existing package: {packageString}");
+                        await log.LogAsync(LogLevel.Minimal, $"Replace existing package: {packageString}");
                     }
                     else
                     {
@@ -230,7 +230,7 @@ namespace Sleet
                 toAdd.Add(package);
             }
 
-            await log.LogAsync(LogLevel.Minimal, $"Processing feed changes");
+            await log.LogAsync(LogLevel.Information, $"Processing feed changes");
 
             // Add/Remove packages
             var changeContext = SleetOperations.Create(existingPackageSets, toAdd, toRemove);

--- a/src/SleetLib/Commands/RecreateCommand.cs
+++ b/src/SleetLib/Commands/RecreateCommand.cs
@@ -29,7 +29,7 @@ namespace Sleet
                 localCache = new LocalCache(tmpPath);
             }
 
-            log.LogMinimal($"Reading feed {source.BaseURI.AbsoluteUri}");
+            log.LogInformation($"Reading feed {source.BaseURI.AbsoluteUri}");
 
             using (var feedLock = await SourceUtility.VerifyInitAndLock(settings, source, "Recreate", log, token))
             {

--- a/src/SleetLib/Commands/RetentionPruneCommand.cs
+++ b/src/SleetLib/Commands/RetentionPruneCommand.cs
@@ -134,13 +134,13 @@ namespace Sleet
 
                 if (exists || symbolsExists)
                 {
-                    await log.LogAsync(LogLevel.Information, $"Pruning {package.ToString()}");
+                    await log.LogAsync(LogLevel.Minimal, $"Pruning {package.ToString()}");
                 }
             }
 
             if (toRemove.Count < 1 && toRemoveSymbols.Count < 1)
             {
-                await log.LogAsync(LogLevel.Information, $"No packages need pruning.");
+                await log.LogAsync(LogLevel.Minimal, $"No packages need pruning.");
             }
             else if (!dryRun)
             {

--- a/src/SleetLib/Commands/ValidateCommand.cs
+++ b/src/SleetLib/Commands/ValidateCommand.cs
@@ -15,7 +15,7 @@ namespace Sleet
         {
             var token = CancellationToken.None;
 
-            log.LogMinimal($"Reading feed {source.BaseURI.AbsoluteUri}");
+            log.LogInformation($"Reading feed {source.BaseURI.AbsoluteUri}");
 
             // Check if already initialized
             using (var feedLock = await SourceUtility.VerifyInitAndLock(settings, source, "Validate", log, token))

--- a/src/SleetLib/Logging/VerbosityUtility.cs
+++ b/src/SleetLib/Logging/VerbosityUtility.cs
@@ -1,0 +1,64 @@
+using System;
+using NuGet.Common;
+
+namespace Sleet
+{
+    /// <summary>
+    /// Maps MSBuild/dotnet-style verbosity level names to the matching <see cref="LogLevel"/> threshold.
+    /// Messages at or above the returned level are written to the console.
+    /// </summary>
+    public static class VerbosityUtility
+    {
+        /// <summary>
+        /// Parse a verbosity level name into a <see cref="LogLevel"/> threshold.
+        /// Supported values (case-insensitive): quiet (q), minimal (m), normal (n),
+        /// detailed (d), diagnostic (diag).
+        /// </summary>
+        /// <exception cref="ArgumentException">Thrown when the value is not a known verbosity level.</exception>
+        public static LogLevel GetLogLevel(string verbosity)
+        {
+            if (TryGetLogLevel(verbosity, out var level))
+            {
+                return level;
+            }
+
+            throw new ArgumentException(
+                $"Invalid verbosity: '{verbosity}'. Valid values are: quiet, minimal, normal, detailed, diagnostic.",
+                nameof(verbosity));
+        }
+
+        /// <summary>
+        /// Try to parse a verbosity level name into a <see cref="LogLevel"/> threshold.
+        /// </summary>
+        /// <returns>True if the value was a known verbosity level.</returns>
+        public static bool TryGetLogLevel(string verbosity, out LogLevel level)
+        {
+            switch (verbosity?.Trim().ToLowerInvariant())
+            {
+                case "quiet":
+                case "q":
+                    level = LogLevel.Warning;
+                    return true;
+                case "minimal":
+                case "m":
+                    level = LogLevel.Minimal;
+                    return true;
+                case "normal":
+                case "n":
+                    level = LogLevel.Information;
+                    return true;
+                case "detailed":
+                case "d":
+                    level = LogLevel.Verbose;
+                    return true;
+                case "diagnostic":
+                case "diag":
+                    level = LogLevel.Debug;
+                    return true;
+                default:
+                    level = LogLevel.Information;
+                    return false;
+            }
+        }
+    }
+}

--- a/test/SleetLib.Tests/VerbosityUtilityTests.cs
+++ b/test/SleetLib.Tests/VerbosityUtilityTests.cs
@@ -1,0 +1,55 @@
+using System;
+using FluentAssertions;
+using NuGet.Common;
+using Sleet;
+using Xunit;
+
+namespace SleetLib.Tests
+{
+    public class VerbosityUtilityTests
+    {
+        [Theory]
+        [InlineData("quiet", LogLevel.Warning)]
+        [InlineData("q", LogLevel.Warning)]
+        [InlineData("minimal", LogLevel.Minimal)]
+        [InlineData("m", LogLevel.Minimal)]
+        [InlineData("normal", LogLevel.Information)]
+        [InlineData("n", LogLevel.Information)]
+        [InlineData("detailed", LogLevel.Verbose)]
+        [InlineData("d", LogLevel.Verbose)]
+        [InlineData("diagnostic", LogLevel.Debug)]
+        [InlineData("diag", LogLevel.Debug)]
+        public void VerbosityUtility_GetLogLevel_MapsKnownValues(string verbosity, LogLevel expected)
+        {
+            VerbosityUtility.GetLogLevel(verbosity).Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineData("Quiet")]
+        [InlineData("MINIMAL")]
+        [InlineData("  detailed  ")]
+        public void VerbosityUtility_GetLogLevel_IsCaseInsensitiveAndTrimmed(string verbosity)
+        {
+            VerbosityUtility.TryGetLogLevel(verbosity, out _).Should().BeTrue();
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("loud")]
+        [InlineData("verbose")]
+        [InlineData(null)]
+        public void VerbosityUtility_TryGetLogLevel_ReturnsFalseForUnknownValues(string verbosity)
+        {
+            VerbosityUtility.TryGetLogLevel(verbosity, out var level).Should().BeFalse();
+            level.Should().Be(LogLevel.Information);
+        }
+
+        [Fact]
+        public void VerbosityUtility_GetLogLevel_ThrowsForUnknownValue()
+        {
+            Action act = () => VerbosityUtility.GetLogLevel("loud");
+
+            act.Should().Throw<ArgumentException>();
+        }
+    }
+}


### PR DESCRIPTION
## Why

[Issue #236](https://github.com/emgarten/Sleet/issues/236) asks for a way to quiet down `push`. Tooling that pushes packages one at a time currently gets 20+ lines of console output per package, most of it the performance summary. There was no way to reduce output, only `--verbose` to increase it.

## What

Rather than a single-purpose `--quiet` flag, this adds an extensible, MSBuild/dotnet-style `--verbosity <level>` option to every command. All commands already funnel through `Util.SetVerbosity`, so they pick it up uniformly.

Levels map to `NuGet.Common.LogLevel` thresholds (messages at or above the threshold are shown):

| `--verbosity` | Level | Push output |
| --- | --- | --- |
| `quiet` | Warning | silent on success (warnings/errors only) |
| `minimal` | Minimal | key progress + result, no perf summary |
| `normal` (default) | Information | unchanged |
| `detailed` | Verbose | same as `--verbose` today |
| `diagnostic` | Debug | full debug output |

For the issue's scenario, `--verbosity minimal` drops a single push from ~22 lines to ~6, and `quiet` to 0 on success.

## Notes

- `--verbose` is kept as an alias for `--verbosity detailed`, so existing scripts are unaffected. Precedence is `SLEET_DEBUG` > `--verbosity` > `--verbose` > default.
- The name-to-level parsing lives in a new public `VerbosityUtility` in SleetLib (with unit tests), keeping it cross-platform testable rather than embedded in the exe.
- An invalid level (e.g. `--verbosity bogus`) fails with a clear message listing the valid values.
- Docs (`doc/commands.md`) and `ReleaseNotes.md` updated.

Verified with `build.sh`: build plus all unit and integration tests pass across net8.0/9.0/10.0.

Closes #236